### PR TITLE
Rev 2: 3A bucks + resolve power/LED/signal change-list items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ hardware/*.kicad_pcb.zip
 stencil_out/
 
 # Script output / generated analysis dumps (machine-specific paths, re-exportable)
+analysis/
 extracted_*.json
 ext2_*.json
 netlist_*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ Design intent — a compact, low-cost FC:
 |---|---|---|---|---|
 | MCU | U2 | RP2354B (QFN-80, 2 MB flash) | C39843328 | — |
 | IMU | U9 | LSM6DSV16XTR (dev part) | C5267406 | SPI0; Rev 2 part undecided — see IMU |
-| 10V buck (switchable) | U3 | LMR51420YFDDCR (2A) | C7296200 | EN=GPIO11; 3A drop-in LMR51430YFDDCR (C5219261) |
-| 5V buck (always-on) | U4 | LMR51420YFDDCR (2A) | C7296200 | same 3A drop-in |
+| 10V buck (switchable) | U3 | LMR51430YFDDCR (3A) | C5219261 | EN=GPIO11; 4.7µH / 22µF 16V / FB 100k:6.49k → 9.85V |
+| 5V buck (always-on) | U4 | LMR51430YFDDCR (3A) | C5219261 | 4.7µH inductor |
 | 5V power mux | U5 | TPS2116DRLR | C3235557 | USB/BATT auto-select (clarify vs TPS2117 in Rev 2) |
 | 3.3V LDO | U7 | LP5912-3.3DRVR | C524780 | 500 mA |
 | 1.8V gyro LDO | U6 | NCV8187AMT180TAG | C893189 | 300 mA (Rev 2: ≥500 mA) |

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Rev 1 boards have been received and brought up. The custom Betaflight target bui
 ### Power tree
 | Rail | Source | Regulator | Notes |
 |---|---|---|---|
-| +10V (switchable) | +BATT | LMR51420YFDDCR (U3, 2A) | EN gated by GPIO11 (PINIO1). VTX/cam rail. 3A drop-in: LMR51430YFDDCR. |
-| +5V (always-on) | +BATT | LMR51420YFDDCR (U4, 2A) | 3A drop-in: LMR51430YFDDCR. |
+| +10V (switchable) | +BATT | LMR51430YFDDCR (U3, 3A) | EN gated by GPIO11 (PINIO1). VTX/cam rail. 4.7µH / 22µF 16V / FB 100k:6.49k → 9.85V. |
+| +5V (always-on) | +BATT | LMR51430YFDDCR (U4, 3A) | 4.7µH inductor. |
 | +5V (USB/BATT mux) | +5V_BUCK + +5V_USB | TPS2116DRLR (U5) | Auto-selects active source. |
 | +3.3V | +5V | LP5912-3.3DRVR (U7) | 500 mA LDO. |
 | +1.8V (gyro analog) | +5V | NCV8187AMT180TAG (U6) | Isolated supply for IMU noise rejection. |
@@ -131,41 +131,48 @@ The RP2350B has 3 PIO blocks × 4 state machines (12 total):
 
 Schematic changes for the next revision. **Schematic and board edits are done manually** — this list is the spec to run down.
 
-Legend: 🔧 field swap (value/part only) · 🔌 wiring / topology change · 🔍 decision / investigation
+Legend: 🔧 field swap (value/part only) · 🔌 wiring / topology change · 🔍 decision / investigation · ✅ resolved / done on Rev 2 schematic
 
 ### Power
-- 🔧 **HW-1 — C28** (10V buck output cap): 16V → **25V**, 22µF 0603. DC-bias derating + transient headroom.
-- 🔧 **HW-2 — R30** (10V FB, bottom of R29=100k divider): 6.8k → **6.34k** (E96). Corrects output 9.42V → 10.06V.
-- 🔧 **HW-3 — L2** (10V inductor): 4.7µH → **10µH** (FTC303020D100MBCA, C7423323). ⚠️ The 10µH was mistakenly applied to **L3 (5V rail)**; **L2 (10V)** is the rail that actually needs it.
-- 🔧 **L3** (5V inductor) field fix: Value says 10µH but MPN/LCSC still the old 4.7µH part. Make consistent — revert to 4.7µH unless 10µH is intended.
-- 🔧 **HW-5 — U3/U4** bucks (optional): LMR51420 (2A) → **LMR51430** (3A), C5219261. Drop-in, same SOT-23-6.
-- 🔧 **HW-8 — U6** gyro LDO: NCV8187 (300 mA) → **≥500 mA** in the same WDFN-6 footprint (part TBD; BF §3.1.2).
+- ✅ **HW-5 — U3/U4 bucks**: LMR51420 (2A) → **LMR51430YFDDCR** (3A, C5219261) — fitted, same SOT-23-6. *Clean the `TI ` prefix out of the MPN field so LCSC/MPN exact-match works for BOM/assembly.*
+- ✅ **HW-2 — R30** (10V FB, R29=100k top): 6.8k → **6.49k** (E96, what was in stock). Vout = 0.6·(1 + 100/6.49) = **9.85V** (~1.5% low — fine).
+- ✅ **HW-1 — C28** (10V buck output cap): **kept 22µF 16V X5R 0603** (decided against 25V). Voltage margin OK (10V on 16V); DC-bias derates effective C to ~7–11µF, which with the 4.7µH inductor raises 10V ripple but is acceptable for a **digital** VTX rail.
+- ✅ **HW-3 — L2/L3 inductors**: **both rails = 4.7µH (XRTC303020D4R7MBCA)** (decided against 10µH on L2). 10V ripple ≈1.17A p-p at 6S; peak well under the 3A part. *Verify the inductor Isat ≥ ~4A.*
+- ✅ **HW-8 — U6 gyro LDO**: **kept NCV8187AMT180TAG** (300 mA) for its PSRR — electrically ample (gyro analog is single-digit mA). ⚠️ BF §3.1.2 lists ≥500 mA; confirm whether that's hard-gated at submission. Low stock → consign if needed.
 
 ### MCU / USB (per Raspberry Pi RP2350 datasheet)
-- 🔧 **R12 / R13** USB series resistors: 30Ω → **27Ω**.
-- 🔧 **R14** VREG_AVDD resistor: 30Ω → **33Ω**.
-- 🔍 **D1** USB ESD (USBLC6-2P6): keep or remove? ESD on USB alone — but not the other exposed pads — is inconsistent. Decide.
+- ✅ **R12/R13/R14**: **no change** — keep all at 30Ω. USB FS is impedance-tolerant (30 vs 27Ω inaudible to enumeration); R14 (VREG_AVDD RC filter) 30 vs 33Ω is negligible. Single resistor value = better DFM.
+- 🔍 **D1 — USB ESD (USBLC6-2P6)**: removed on current schematic. ⚠️ **Recommend restoring.** USB is the most-handled / most-exposed interface; the RP2354B PHY isn't rated for system-level (IEC 61000-4-2 8kV) ESD, and the part is tiny/cheap/low-C. The "inconsistency" argument favors adding TVS to the *other* exposed I/O, not stripping USB. **Pending final call.**
 
 ### LEDs
-- 🔌 All status/indicator LEDs: **0201 → 0402** (0201 too fragile — broke during nut install). Footprint change.
-- 🔧 **HW-4 — D2** (LED0 status, GPIO12): green → **blue** (BF §3.1.4.6 requires blue LED0). D4/D5/D7/D10 are power-rail indicators.
-- 🔧 LED series resistors: raise (too bright); recompute per rail voltage. Production colors TBD (purple needs >3.3V).
+- ✅ All indicator LEDs **0201 → 0402** (0201 too fragile — broke during nut install).
+- ✅ **HW-4 — D2** (LED0 status, GPIO12): green → **blue** (XL-1005UBC, C22355736). BF §3.1.4.6.
+- ✅ **LED series resistors recalculated for ~1mA** (greens = XL-1005UGC, C965793). Vf@1mA estimated: blue ≈2.75V, green ≈2.6V.
+
+  | LED | Color | Source | Old R | **New R (E24)** | I |
+  |---|---|---|---|---|---|
+  | D2 (LED0) | Blue | GPIO12 (~3.3V) | 30R | **510Ω** | ~1.0mA |
+  | D7 | Green | +3.3V | 30R | **680Ω** | ~1.0mA |
+  | D5 | Green | +5V (5V_BUCK) | 200R | **2.4kΩ** | ~1.0mA |
+  | D4 | Green | +10V | 470R | **7.5kΩ** | ~1.0mA |
+
+  D2/D7 sit on 3.3V with low headroom → current is Vf-sensitive; if dim, D2→430Ω, D7→560Ω. Optional: D2→330Ω (~2mA) for daylight pre-arm visibility.
 
 ### Signals / connectivity (wiring — manual)
 - 🔌 **SPI0 cleanup**: group **GYRO_CS** into the SPI bus (with SCK/MOSI/MISO); drop the IMU **CLKIN/SYNC** net (GPIO15) — ST gyros have no SYNC. Same regroup for **FLASH_CS** (SD). ⚠️ If a TDK IMU is chosen, CLKIN is useful — couple to the IMU decision.
-- 🔌 **Remove SBUS inverter** (GPIO9 / SBUS_INVERT circuit).
+- ✅ **SBUS inverter removed** (GPIO9). Confirmed safe: BF PICO inverts at the RP2350 pad IO-mux (`gpio_set_inover/outover(GPIO_OVERRIDE_INVERT)`), auto-set for SBUS, works on native + PIO UARTs. The SBUS line wires straight to a UART/PIO-UART **RX** GPIO; firmware inverts.
 - 🔌 **HW-6 — ESC connector P1**: mirror reversed pinout **+ add telemetry pin** (BF 8-pin: Current = pin 3, Telem = pin 4). **Safety-critical** — current pinout shorts VBAT to a GPIO on a standard BF harness.
 - 🔌 **HW-7** — Add **battery reverse-polarity protection** (PMOS RPP).
-- 🔌 **HW-11 — Beeper**: active buzzer + NPN driver (300–1000Ω base R) per BF §3.1.4.
-- 🔌 **SD card**: wire compatible with both SPI and SDIO; use SPI for now, switch to SDIO via a BF update if supported on Pico.
+- ✅ **HW-11 — Beeper**: done — **N-MOS low-side switch** (Q2 DMN1150UFB-7B, R20 1k gate, R23 100k pulldown, BEEPER = GPIO6). Better than the NPN spec. *Verify: (1) flyback diode is across the buzzer (cathode → +supply, anode → drain), not just the FET body diode; (2) DMN1150UFB-7B is logic-level (turns on hard at 3.3V).*
+- 🔌 **SD card**: wire compatible with both SPI and SDIO; use SPI for now (see SDIO decision below).
 
 ### Decisions / investigations
 - 🔍 **IMU** — undecided for Rev 2; see [IMU](#imu).
-- 🔍 **U5 power MUX** — clarify TPS2116 vs TPS2117 (which part/behavior is intended).
-- 🔍 **SDIO on Pico** — does Betaflight support SDIO blackbox on RP2350B? (Madflight wants it too.)
-- 🔍 **CRIT-2 — motor order** M1–M4 reversed vs the Betaflight RP2350B reference config — resolve in the firmware target or swap silk.
+- ✅ **U5 power MUX** — **TPS2116DRLR** confirmed (auto-select USB/BATT).
+- ✅ **SDIO on Pico** — **stay on SPI.** Betaflight PICO supports SD blackbox over **SPI only** (PR #14567); no SDIO under `src/platform/PICO/`, no open PR. SDIO would give ~10× throughput (~25 MB/s vs ~2 MB/s — needed for 4kHz+ full-field logging) but requires a 4-bit HW bus *and* firmware that doesn't exist. SPI1 microSD is correct.
+- ✅ **CRIT-2 — motor order**: keep reversed silk (eases routing); **resolve in the BF target's DShot motor resource order** so M1–M4 map to the pads. Documented in the target.
 - 🔍 **CRIT-3 — FB_OSD upstream**: the RP2350B analog-OSD driver PR stack (#14882) is still open; no flyable upstream binary yet. Track before tape-out.
-- 🔍 Add **SWD connector** (4-pin JST SH: 3V3/GND/SWDIO/SWCLK) per BF.
+- ✅ **SWD connector** — **not adding.** RP2354B flashes over USB (UF2/BOOTSEL); SWD is only for live debug. Optional test pads cost nothing but no connector needed.
 
 ## Repository Structure
 

--- a/hardware/OpenFC.kicad_pro
+++ b/hardware/OpenFC.kicad_pro
@@ -715,7 +715,7 @@
         "uuid": "fb88b6f9-ee39-4640-a9d4-04a17ceeac64"
       }
     ],
-    "used_designators": "D10,R40,C30",
+    "used_designators": "D4-5,D7-8,D10,R40,C30",
     "variants": []
   },
   "sheets": [

--- a/hardware/power.kicad_sch
+++ b/hardware/power.kicad_sch
@@ -4572,6 +4572,121 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:LED")
+		(at 257.81 39.37 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "13d101a1-671c-4968-88d5-af14e4998e34")
+		(property "Reference" "D8"
+			(at 261.62 39.6874 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_1_Green"
+			(at 261.62 42.2274 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0402_1005Metric"
+			(at 257.81 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 257.81 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 257.81 39.37 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC" "C965793"
+			(at 257.81 39.37 90)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "XL-1005UGC "
+			(at -49.53 -30.48 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XINGLIGHT"
+			(at -49.53 -30.48 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "7b0adb38-9428-4457-9484-a2fcc4c9d0f1")
+		)
+		(pin "1"
+			(uuid "63bd1a08-ff07-4dac-b773-022548449d2f")
+		)
+		(instances
+			(project "OpenFC"
+				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R")
 		(at 116.84 88.9 180)
 		(unit 1)
@@ -5823,6 +5938,121 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:LED")
+		(at 140.97 99.06 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4ba57cfb-d914-45f4-9a08-37ca48819871")
+		(property "Reference" "D5"
+			(at 144.78 99.3774 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_1_Green"
+			(at 144.78 101.9174 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0402_1005Metric"
+			(at 140.97 99.06 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 140.97 99.06 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 140.97 99.06 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC" "C965793"
+			(at 140.97 99.06 90)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "XL-1005UGC "
+			(at -166.37 29.21 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XINGLIGHT"
+			(at -166.37 29.21 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "d69c66f4-3d24-41a5-8bc4-22a4858082e8")
+		)
+		(pin "1"
+			(uuid "827b6e48-d63c-4ba9-868d-aac5d35f19c1")
+		)
+		(instances
+			(project "OpenFC"
+				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "lib:XRTC303020D4R7MBCA")
 		(at 102.87 38.1 0)
 		(unit 1)
@@ -6164,121 +6394,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
 					(reference "#PWR081")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:LED")
-		(at 140.97 57.15 90)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "614f1a85-1bdd-476a-81c5-7888307abf2c")
-		(property "Reference" "D4"
-			(at 144.78 57.4674 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "LED_1_Green"
-			(at 144.78 60.0074 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0201_0603Metric"
-			(at 140.97 57.15 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 140.97 57.15 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 140.97 57.15 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C3646922"
-			(at 140.97 57.15 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "XL-0201UGC"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "XINGLIGHT"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "d6b00dae-6042-4656-aa04-6d329b5ec78a")
-		)
-		(pin "1"
-			(uuid "13b80ae3-5bab-4e88-ada7-505124dcfc92")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
-					(reference "D4")
 					(unit 1)
 				)
 			)
@@ -6707,6 +6822,121 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:LED")
+		(at 252.73 113.03 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7331a554-c648-41cb-8171-acbdc7c37388")
+		(property "Reference" "D7"
+			(at 256.54 113.3474 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_1_Green"
+			(at 256.54 115.8874 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0402_1005Metric"
+			(at 252.73 113.03 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 252.73 113.03 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 252.73 113.03 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC" "C965793"
+			(at 252.73 113.03 90)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "XL-1005UGC "
+			(at -54.61 43.18 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XINGLIGHT"
+			(at -54.61 43.18 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "9bb1ca9d-dce7-4b03-b11d-e28bec234c85")
+		)
+		(pin "1"
+			(uuid "5da78cbb-07cf-4369-8db1-a86fd0531b0f")
+		)
+		(instances
+			(project "OpenFC"
+				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "lib:LMR51420YDDCR")
 		(at 69.85 82.55 0)
 		(unit 1)
@@ -6728,7 +6958,7 @@
 				)
 			)
 		)
-		(property "Value" "LMR51420YFDDCR"
+		(property "Value" "TI LMR51430YFDDCR"
 			(at 69.85 74.93 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6771,7 +7001,7 @@
 				)
 			)
 		)
-		(property "LCSC Part" "C7296200"
+		(property "LCSC Part" "C5219261"
 			(at 69.85 95.25 0)
 			(hide yes)
 			(show_name no)
@@ -6782,7 +7012,7 @@
 				)
 			)
 		)
-		(property "MPN" "LMR51420YFDDCR"
+		(property "MPN" "TI LMR51430YFDDCR"
 			(at 0 0 0)
 			(hide yes)
 			(show_name no)
@@ -7699,121 +7929,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:LED")
-		(at 140.97 99.06 90)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "97748cf0-2041-4b8a-b335-b34978be7ebf")
-		(property "Reference" "D5"
-			(at 144.78 99.3774 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "LED_1_Green"
-			(at 144.78 101.9174 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0201_0603Metric"
-			(at 140.97 99.06 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 140.97 99.06 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 140.97 99.06 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C3646922"
-			(at 140.97 99.06 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "XL-0201UGC"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "XINGLIGHT"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "23541cb1-cf5c-48f6-928b-4badab950bd1")
-		)
-		(pin "1"
-			(uuid "dbf8a9f1-2adb-4864-950a-5744b188d727")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
-					(reference "D5")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:R")
 		(at 241.3 50.8 180)
 		(unit 1)
@@ -8365,7 +8480,7 @@
 				)
 			)
 		)
-		(property "Value" "FTC303020D100MBCA"
+		(property "Value" "XRTC303020D4R7MBCA"
 			(at 102.87 76.2 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8408,7 +8523,7 @@
 				)
 			)
 		)
-		(property "LCSC Part" "C7423323"
+		(property "LCSC Part" "C39846837"
 			(at 102.87 90.17 0)
 			(hide yes)
 			(show_name no)
@@ -8750,7 +8865,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "6.8k"
+		(property "Value" "6.49k"
 			(at 119.38 58.4199 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8794,7 +8909,7 @@
 				)
 			)
 		)
-		(property "LCSC" "C274877"
+		(property "LCSC" "C474786"
 			(at 116.84 57.15 0)
 			(hide yes)
 			(show_name no)
@@ -9030,121 +9145,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
 					(reference "#PWR074")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:LED")
-		(at 252.73 113.03 90)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "ca22d604-178a-4ca2-a37d-dc33913d7855")
-		(property "Reference" "D7"
-			(at 256.54 113.3474 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "LED_1_Green"
-			(at 256.54 115.8874 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0201_0603Metric"
-			(at 252.73 113.03 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 252.73 113.03 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 252.73 113.03 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C3646922"
-			(at 252.73 113.03 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "XL-0201UGC"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "XINGLIGHT"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "b35a18f8-907f-4787-b81c-18a9c6719e2c")
-		)
-		(pin "1"
-			(uuid "1ccfbb69-8c5d-4354-a6c1-dd3b018579d8")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
-					(reference "D7")
 					(unit 1)
 				)
 			)
@@ -9721,6 +9721,121 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:LED")
+		(at 140.97 57.15 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e3d68c12-f6c8-4661-a78c-49e9a1f42a45")
+		(property "Reference" "D4"
+			(at 144.78 57.4674 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_1_Green"
+			(at 144.78 60.0074 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0402_1005Metric"
+			(at 140.97 57.15 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 140.97 57.15 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 140.97 57.15 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC" "C965793"
+			(at 140.97 57.15 90)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "XL-1005UGC "
+			(at -166.37 -12.7 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XINGLIGHT"
+			(at -166.37 -12.7 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "a638cc45-4c7f-4500-81db-99b0f188fb07")
+		)
+		(pin "1"
+			(uuid "b0b2ceab-91b7-418a-a11c-9de6aa6453de")
+		)
+		(instances
+			(project "OpenFC"
+				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:+BATT")
 		(at 41.91 38.1 0)
 		(unit 1)
@@ -9820,7 +9935,7 @@
 				)
 			)
 		)
-		(property "Value" "LMR51420YFDDCR"
+		(property "Value" "TI LMR51430YFDDCR"
 			(at 69.85 33.02 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9863,7 +9978,7 @@
 				)
 			)
 		)
-		(property "LCSC Part" "C7296200"
+		(property "LCSC Part" "C5219261"
 			(at 69.85 53.34 0)
 			(hide yes)
 			(show_name no)
@@ -9874,7 +9989,7 @@
 				)
 			)
 		)
-		(property "MPN" "LMR51420YFDDCR"
+		(property "MPN" "TI LMR51430YFDDCR"
 			(at 0 0 0)
 			(hide yes)
 			(show_name no)
@@ -10075,121 +10190,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
 					(reference "#PWR072")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:LED")
-		(at 257.81 39.37 90)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "fca98023-6b55-4e57-835b-e9548d654853")
-		(property "Reference" "D10"
-			(at 261.62 39.6874 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "LED_1_Green"
-			(at 261.62 42.2274 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0201_0603Metric"
-			(at 257.81 39.37 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 257.81 39.37 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 257.81 39.37 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C3646922"
-			(at 257.81 39.37 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "XL-0201UGC"
-			(at 0 -10.16 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "XINGLIGHT"
-			(at 0 -10.16 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "e80b9c42-7d92-46a0-b671-768f6dc48039")
-		)
-		(pin "1"
-			(uuid "dc481135-cdef-430a-8f19-9b723f3d4312")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/f8522f96-c979-41d2-ae00-e5ad899a3161"
-					(reference "D10")
 					(unit 1)
 				)
 			)

--- a/hardware/rp2350a.kicad_sch
+++ b/hardware/rp2350a.kicad_sch
@@ -3031,457 +3031,6 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "lib:USBLC6-2SC6"
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "D"
-				(at 0 12.7 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "USBLC6-2SC6"
-				(at 0 -12.7 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" "lib:SOT-23-6_L2.9-W1.6-P0.95-LS2.8-BL"
-				(at 0 -15.24 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Datasheet" "https://lcsc.com/product-detail/Diodes-ESD_STMicroelectronics_USBLC6-2SC6_USBLC6-2SC6_C7519.html"
-				(at 0 -17.78 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "LCSC Part" "C7519"
-				(at 0 -20.32 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "USBLC6-2SC6_0_1"
-				(rectangle
-					(start -11.43 12.7)
-					(end 11.43 -12.7)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy -11.43 7.62) (xy 11.43 7.62)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -11.43 0) (xy 11.43 0)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -11.43 -7.62) (xy 11.43 -7.62)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center -8.64 0)
-					(radius 0.25)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -8.64 0) (xy -8.64 5.08) (xy 8.38 5.08) (xy 8.38 -5.08) (xy -8.64 -5.08) (xy -8.64 0)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy -6.1 -6.6) (xy -3.56 -5.08) (xy -6.1 -3.3) (xy -6.1 -6.6)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy -5.84 3.56) (xy -3.3 5.08) (xy -5.84 6.86) (xy -5.84 3.56)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.56 -3.05) (xy -3.56 -3.05) (xy -3.56 -6.86) (xy -3.56 -6.86)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -3.3 7.11) (xy -3.3 7.11) (xy -3.3 3.3) (xy -3.3 3.3)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.78 -1.52) (xy 0.76 0) (xy -1.78 1.78) (xy -1.78 -1.52)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(circle
-					(center 0 7.62)
-					(radius 0.25)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 0 7.62) (xy 0 5.08)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center 0 5.08)
-					(radius 0.25)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center 0 -5.08)
-					(radius 0.25)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 0 -7.62) (xy 0 -5.08)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center 0 -7.62)
-					(radius 0.25)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 1.27 2.03) (xy 0.76 2.03) (xy 0.76 -1.78) (xy 0 -1.78)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 2.79 3.56) (xy 5.33 5.08) (xy 2.79 6.86) (xy 2.79 3.56)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy 2.79 -6.6) (xy 5.33 -5.08) (xy 2.79 -3.3) (xy 2.79 -6.6)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type background)
-					)
-				)
-				(polyline
-					(pts
-						(xy 5.33 7.11) (xy 5.33 7.11) (xy 5.33 3.3) (xy 5.33 3.3)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 5.33 -3.05) (xy 5.33 -3.05) (xy 5.33 -6.86) (xy 5.33 -6.86)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(circle
-					(center 8.38 0)
-					(radius 0.25)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(pin input line
-					(at -16.51 7.62 0)
-					(length 5.08)
-					(name "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin input line
-					(at -16.51 0 0)
-					(length 5.08)
-					(name "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin input line
-					(at -16.51 -7.62 0)
-					(length 5.08)
-					(name "3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin input line
-					(at 16.51 -7.62 180)
-					(length 5.08)
-					(name "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin input line
-					(at 16.51 0 180)
-					(length 5.08)
-					(name "5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin input line
-					(at 16.51 7.62 180)
-					(length 5.08)
-					(name "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
 		(symbol "lib:XTM25012000JT00351001"
 			(exclude_from_sim no)
 			(in_bom yes)
@@ -4454,18 +4003,6 @@
 		(uuid "68b26a0a-cc90-42c4-9ebf-d3a0e63c4844")
 	)
 	(rectangle
-		(start 327.66 91.44)
-		(end 393.7 142.24)
-		(stroke
-			(width 0.508)
-			(type solid)
-		)
-		(fill
-			(type none)
-		)
-		(uuid "7bbb8ff1-84fc-403a-8ac1-4463d5778ad4")
-	)
-	(rectangle
 		(start 143.51 147.32)
 		(end 213.36 167.64)
 		(stroke
@@ -4706,18 +4243,6 @@
 		)
 		(uuid "963dc383-df36-4d27-9f3c-91c148a32235")
 	)
-	(text "SBUS inverter"
-		(exclude_from_sim no)
-		(at 348.742 106.68 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(thickness 0.254)
-				(bold yes)
-			)
-		)
-		(uuid "bae88dda-a5fa-4d35-8ff2-4dc9afa75496")
-	)
 	(text "RC lowpass filters on ADC and VREG like Pico datasheet"
 		(exclude_from_sim no)
 		(at 225.806 54.864 0)
@@ -4833,12 +4358,6 @@
 		(uuid "419ab2d4-3d24-42b1-8fec-f519aca588d6")
 	)
 	(junction
-		(at 361.95 110.49)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "4d883b9a-24b8-425e-92e5-da41b49aeb4a")
-	)
-	(junction
 		(at 229.87 76.2)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -4861,12 +4380,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "60692674-72a4-46b4-8b96-3f9de817f977")
-	)
-	(junction
-		(at 361.95 125.73)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "6315bf4c-2fe4-45b0-997b-2db7c0f5aba7")
 	)
 	(junction
 		(at 351.79 170.18)
@@ -4951,12 +4464,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "b452edb0-9669-43b6-8f26-92d7dd680b33")
-	)
-	(junction
-		(at 350.52 115.57)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "c619c84b-dbab-4d8a-82db-a617af4e1333")
 	)
 	(junction
 		(at 313.69 147.32)
@@ -5199,16 +4706,6 @@
 	)
 	(wire
 		(pts
-			(xy 361.95 125.73) (xy 361.95 127)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0e6549d1-8339-4cf6-82e9-d375eed1b131")
-	)
-	(wire
-		(pts
 			(xy 158.75 184.15) (xy 158.75 198.12)
 		)
 		(stroke
@@ -5409,16 +4906,6 @@
 	)
 	(wire
 		(pts
-			(xy 361.95 110.49) (xy 373.38 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2a73fc39-93d2-4700-8fd5-36976fcaa123")
-	)
-	(wire
-		(pts
 			(xy 50.8 72.39) (xy 50.8 77.47)
 		)
 		(stroke
@@ -5456,16 +4943,6 @@
 			(type default)
 		)
 		(uuid "2e1fb81e-e8c6-4603-a7c7-877443766e24")
-	)
-	(wire
-		(pts
-			(xy 350.52 125.73) (xy 361.95 125.73)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2f916311-3d8d-4cfc-8cee-d996cedae2df")
 	)
 	(bus
 		(pts
@@ -5959,16 +5436,6 @@
 	)
 	(wire
 		(pts
-			(xy 350.52 115.57) (xy 350.52 118.11)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "87251162-8693-44aa-8e7e-7c5a9f79f725")
-	)
-	(wire
-		(pts
 			(xy 109.22 166.37) (xy 116.84 166.37)
 		)
 		(stroke
@@ -5986,26 +5453,6 @@
 			(type default)
 		)
 		(uuid "8783a19b-3013-4a62-94ee-ebcb52877f74")
-	)
-	(wire
-		(pts
-			(xy 361.95 123.19) (xy 361.95 125.73)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8c9dcb8b-8e11-44d2-8f6d-e2b9a8057ce4")
-	)
-	(wire
-		(pts
-			(xy 337.82 115.57) (xy 340.36 115.57)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8dbb87cb-1a7e-4840-99c2-459b3be558fd")
 	)
 	(wire
 		(pts
@@ -6096,16 +5543,6 @@
 			(type default)
 		)
 		(uuid "9d9b4db5-1175-4087-9290-92f83431a06d")
-	)
-	(wire
-		(pts
-			(xy 361.95 109.22) (xy 361.95 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9e033e48-55cb-4827-8d7f-a73d936a48a4")
 	)
 	(wire
 		(pts
@@ -6339,16 +5776,6 @@
 	)
 	(wire
 		(pts
-			(xy 361.95 99.06) (xy 361.95 101.6)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b9adaf5d-d963-453b-a7f8-4c0429b9b721")
-	)
-	(wire
-		(pts
 			(xy 363.22 177.8) (xy 363.22 180.34)
 		)
 		(stroke
@@ -6416,16 +5843,6 @@
 			(type default)
 		)
 		(uuid "bd8dcde1-aeff-4cc4-8fa1-08cddc94fb44")
-	)
-	(wire
-		(pts
-			(xy 350.52 115.57) (xy 354.33 115.57)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "bf3c3774-f1b3-43c2-b93f-bffa6bab6cc0")
 	)
 	(wire
 		(pts
@@ -6636,16 +6053,6 @@
 			(type default)
 		)
 		(uuid "e26cd625-b08e-4e13-a869-2378e2d9a837")
-	)
-	(wire
-		(pts
-			(xy 347.98 115.57) (xy 350.52 115.57)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e39e20e5-dbe5-4ba7-a540-75ac86589892")
 	)
 	(wire
 		(pts
@@ -6867,26 +6274,6 @@
 		)
 		(uuid "326c2f30-8af6-4761-9f0d-569fa157ba2b")
 	)
-	(label "D+"
-		(at 133.35 207.01 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "36548fa2-c868-484b-bd3e-4119c9d6db1d")
-	)
-	(label "SBUS_INVERT"
-		(at 373.38 110.49 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "4d75878d-d8b8-4455-adcc-859b64aa2b11")
-	)
 	(label "XIN"
 		(at 199.39 105.41 180)
 		(effects
@@ -6940,16 +6327,6 @@
 		)
 		(uuid "6267873b-05ae-4c39-9c5b-72b378984672")
 	)
-	(label "D-_C"
-		(at 100.33 222.25 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "67e4e53b-aaa3-4c1d-846a-d2362aee43f5")
-	)
 	(label "SPI0.MOSI"
 		(at 265.43 115.57 180)
 		(effects
@@ -6991,16 +6368,6 @@
 		)
 		(uuid "8c799c9f-d9f1-4186-b8a8-5f9b0ed6b168")
 	)
-	(label "D+_C"
-		(at 100.33 207.01 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "90bcee6a-13f3-4c99-ae76-d9ec7ba9ce18")
-	)
 	(label "D-"
 		(at 184.15 116.84 180)
 		(effects
@@ -7032,26 +6399,6 @@
 			(justify left bottom)
 		)
 		(uuid "a87f9442-7e86-481c-ae12-d997372ea6b5")
-	)
-	(label "SBUS_INVERT"
-		(at 199.39 204.47 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "b4392504-ca6a-4235-a81e-3c73ab260c8e")
-	)
-	(label "D-"
-		(at 133.35 222.25 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "c0456146-78bf-48b8-827e-71387d74a239")
 	)
 	(label "SPI1.MISO"
 		(at 265.43 135.89 180)
@@ -7159,6 +6506,17 @@
 			(justify right)
 		)
 		(uuid "1ea99708-b5d8-4c8b-b392-0cadc7a9bce8")
+	)
+	(hierarchical_label "SBUS"
+		(shape input)
+		(at 199.39 204.47 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2d90317a-c498-45b7-b6ce-447b7920e003")
 	)
 	(hierarchical_label "FLASH_CS"
 		(shape input)
@@ -7324,17 +6682,6 @@
 			(justify left)
 		)
 		(uuid "a08f73eb-8ea6-417d-930b-cd7f1660fe8a")
-	)
-	(hierarchical_label "SBUS"
-		(shape input)
-		(at 337.82 115.57 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right)
-		)
-		(uuid "a38d2cc8-6258-40b3-99c4-19f92215b0ef")
 	)
 	(hierarchical_label "BUZZER-"
 		(shape input)
@@ -9252,84 +8599,6 @@
 		)
 	)
 	(symbol
-		(lib_id "power:VBUS")
-		(at 133.35 214.63 270)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "24d12565-7a03-4d65-a05c-e458c8ef87cb")
-		(property "Reference" "#PWR033"
-			(at 129.54 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "+5V_USB"
-			(at 138.43 214.63 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 133.35 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 133.35 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 133.35 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "1"
-			(uuid "f034435c-d71c-4ce9-8381-9d0d287e7fba")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "#PWR033")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:R")
 		(at 345.44 170.18 270)
 		(unit 1)
@@ -9550,118 +8819,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
 					(reference "C11")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 344.17 115.57 270)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(uuid "26fba909-f732-4398-a481-bb4b2a3f6b13")
-		(property "Reference" "R19"
-			(at 344.17 110.236 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "1k"
-			(at 344.17 112.776 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0201_0603Metric"
-			(at 344.17 113.792 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 344.17 115.57 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 344.17 115.57 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C270365"
-			(at 344.17 115.57 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "0201WMF1001TEE"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "UNI-ROYAL"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "b5817f25-0cee-4bd2-a2f6-7ae696a6797f")
-		)
-		(pin "1"
-			(uuid "d6144e4c-3e12-4cff-85c2-261c04d12420")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "R19")
 					(unit 1)
 				)
 			)
@@ -10956,118 +10113,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 350.52 121.92 180)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(uuid "53e53f8e-c5f8-43c6-bd39-73b6ec258511")
-		(property "Reference" "R21"
-			(at 345.694 122.174 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "100k"
-			(at 347.472 122.174 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0201_0603Metric"
-			(at 352.298 121.92 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 350.52 121.92 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 350.52 121.92 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C270364"
-			(at 350.52 121.92 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "0201WMF1003TEE"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "UNI-ROYAL"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "1"
-			(uuid "de777d98-cc28-481e-a13a-b16783e08226")
-		)
-		(pin "2"
-			(uuid "e2bca433-2c71-4eec-a9e9-4751a2e3a608")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "R21")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:GND")
 		(at 148.59 77.47 0)
 		(unit 1)
@@ -11822,84 +10867,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
 					(reference "R1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 100.33 214.63 270)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "5ccc8928-2b90-4d53-84bc-024a18215db4")
-		(property "Reference" "#PWR027"
-			(at 93.98 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "GND"
-			(at 95.25 214.63 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 100.33 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 100.33 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 100.33 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "1"
-			(uuid "c3c5c813-280e-453b-9d1c-51cdfaa29adc")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "#PWR027")
 					(unit 1)
 				)
 			)
@@ -15022,124 +13989,6 @@
 		)
 	)
 	(symbol
-		(lib_id "lib:DMN1150UFB-7B")
-		(at 361.95 115.57 0)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "a7282937-0f7e-4acf-a009-0c952bbec6ef")
-		(property "Reference" "Q1"
-			(at 367.03 115.5699 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "DMN1150UFB-7B"
-			(at 367.03 118.1099 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "lib:DFN-3L_L1.0-W0.6-P0.65-BR"
-			(at 361.95 130.81 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 361.95 115.57 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 361.95 115.57 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC Part" "C459538"
-			(at 361.95 133.35 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "DMN1150UFB-7B"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "Diodes Incorporated"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "3"
-			(uuid "67d6b940-81d9-48e8-beaf-f7d799d9e9b0")
-		)
-		(pin "2"
-			(uuid "a70a4ef0-cce1-4bb6-852e-d2016020ed84")
-		)
-		(pin "1"
-			(uuid "dc19521c-fd25-4b8a-b6ee-cad60447ce0c")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "Q1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:+3.3V")
 		(at 76.2 60.96 0)
 		(unit 1)
@@ -15290,84 +14139,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
 					(reference "#PWR026")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 361.95 127 0)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(uuid "ae2ff9c4-3ee7-45f1-b118-81c531f999c0")
-		(property "Reference" "#PWR061"
-			(at 361.95 133.35 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "GND"
-			(at 361.9501 130.81 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" ""
-			(at 361.95 127 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 361.95 127 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 361.95 127 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "1"
-			(uuid "2c99fd4e-99a3-4f4e-841e-6130c99ba59a")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "#PWR061")
 					(unit 1)
 				)
 			)
@@ -16414,118 +15185,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 361.95 105.41 180)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(uuid "c426c97f-4bc7-46cc-9605-273541404ad0")
-		(property "Reference" "R24"
-			(at 364.49 105.156 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "10k"
-			(at 367.03 105.156 90)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0201_0603Metric"
-			(at 363.728 105.41 90)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 361.95 105.41 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 361.95 105.41 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC" "C106225"
-			(at 361.95 105.41 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "RC0201FR-0710KL"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "YAGEO"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "3a1d496c-db08-4eab-9e6f-9f46690f39f1")
-		)
-		(pin "1"
-			(uuid "123aaefb-55bd-4b7b-93b2-7eab25f65b17")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "R24")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:C")
 		(at 172.72 201.93 0)
 		(unit 1)
@@ -16635,132 +15294,6 @@
 			(project "OpenFC"
 				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
 					(reference "C20")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "lib:USBLC6-2SC6")
-		(at 116.84 214.63 0)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(uuid "c71a11a5-a03d-4d21-ab9e-645c0d284727")
-		(property "Reference" "D1"
-			(at 122.682 200.66 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "USBLC6-2P6"
-			(at 122.682 198.12 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "Package_TO_SOT_SMD:SOT-666"
-			(at 116.84 229.87 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" "https://lcsc.com/product-detail/Diodes-ESD_STMicroelectronics_USBLC6-2SC6_USBLC6-2SC6_C7519.html"
-			(at 116.84 232.41 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 116.84 214.63 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "LCSC Part" "C15999"
-			(at 116.84 234.95 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "MPN" "USBLC6-2P6"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Manufacturer" "STMicroelectronics"
-			(at 0 0 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "4"
-			(uuid "16fbd057-b534-4e22-9c5f-1baff5555298")
-		)
-		(pin "3"
-			(uuid "446cb662-9930-48f6-8d1e-b47d4ee3d6d4")
-		)
-		(pin "2"
-			(uuid "dd3ba466-bcb4-488e-afdc-6bee60fac03f")
-		)
-		(pin "6"
-			(uuid "ad3d8637-351f-4ae8-91bd-d8e76206d71c")
-		)
-		(pin "1"
-			(uuid "8e5626ac-0f39-4eb4-ae4e-9847abcc92d8")
-		)
-		(pin "5"
-			(uuid "a024f776-6f41-46a6-86c3-eca05c801696")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "D1")
 					(unit 1)
 				)
 			)
@@ -18524,84 +17057,6 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 361.95 99.06 0)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "f0cb541a-4c82-48f5-9b33-05117b1b3436")
-		(property "Reference" "#PWR060"
-			(at 361.95 102.87 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "+3.3V"
-			(at 361.95 93.98 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 361.95 99.06 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 361.95 99.06 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 361.95 99.06 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "1"
-			(uuid "59a100fd-a9f2-4d9b-8527-c23307eddb01")
-		)
-		(instances
-			(project "OpenFC"
-				(path "/fb88b6f9-ee39-4640-a9d4-04a17ceeac64/cec45a0d-1d48-4800-9760-14c521e5fc8b"
-					(reference "#PWR060")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:+3.3V")
 		(at 350.52 205.74 0)
 		(unit 1)
 		(body_style 1)
@@ -19239,7 +17694,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "LED_1_Green"
+		(property "Value" "LED_1_Blue"
 			(at 311.15 72.7074 90)
 			(show_name no)
 			(do_not_autoplace no)
@@ -19250,7 +17705,7 @@
 				(justify right)
 			)
 		)
-		(property "Footprint" "LED_SMD:LED_0201_0603Metric"
+		(property "Footprint" "LED_SMD:LED_0402_1005Metric"
 			(at 307.34 69.85 0)
 			(hide yes)
 			(show_name no)
@@ -19283,7 +17738,7 @@
 				)
 			)
 		)
-		(property "LCSC" "C3646922"
+		(property "LCSC" "C22355736"
 			(at 307.34 69.85 90)
 			(hide yes)
 			(show_name no)
@@ -19294,7 +17749,7 @@
 				)
 			)
 		)
-		(property "MPN" "XL-0201UGC"
+		(property "MPN" "XL-1005UBC"
 			(at 0 0 0)
 			(hide yes)
 			(show_name no)


### PR DESCRIPTION
Syncs the Rev 2 schematic edits (power, rp2350a) with documented decisions, and resolves the README Rev 2 Change List accordingly.

## Power
- **U3/U4 bucks** LMR51420 (2A) → **LMR51430YFDDCR** (3A, C5219261)
- **10V FB R30** → 6.49k (E96, what was in stock) → **Vout 9.85V** (~1.5% low, fine)
- **C28** kept **22µF 16V X5R 0603** — acceptable for a digital-VTX rail
- **L2/L3** both rails **4.7µH** (XRTC303020D4R7MBCA)
- **U6 gyro LDO** kept **NCV8187** (300mA) for PSRR — ⚠️ check BF §3.1.2 ≥500mA checklist

## MCU / USB
- **R12/R13/R14** kept at 30Ω (DFM consolidation, no measurable impact)
- **D1 USB ESD** removed on schematic — ⚠️ **recommendation is to restore it** (USB is the most-exposed interface; RP2354B PHY isn't rated for system-level ESD). Pending final call.

## LEDs
- **D2 LED0** → blue (XL-1005UBC); greens XL-1005UGC; all **0402**
- Series resistors recalculated for **~1mA**: D2 510Ω, D7 680Ω, D5 2.4kΩ, D4 7.5kΩ

## Signals / decisions
- **SBUS inverter removed** — BF PICO inverts at the RP2350 pad IO-mux (verified in source)
- **Beeper done** — N-MOS low-side (Q2 DMN1150UFB-7B); verify flyback diode + logic-level threshold
- **SDIO blackbox** — staying on SPI; Betaflight PICO has no SDIO support (PR #14567 is SPI-only)
- **CRIT-2 motor order** — keep reversed silk, resolve in BF target DShot resource map
- **U5** confirmed TPS2116; **SWD connector** not added (USB/BOOTSEL flashing)

## Open items still in the change list
SPI0 cleanup (pending IMU decision), ESC P1 pinout (HW-6, safety-critical), reverse-polarity protection (HW-7), FB_OSD upstream (CRIT-3), D1 ESD final call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)