### PR TITLE
Adopt OpenDrone repo standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ _autosave-*
 
 # KiCad generated/local
 *.kicad_prl
-*.kicad_dru
 *.kicad_sch-bak
 *.kicad_pcb-bak
 *.lck
@@ -25,15 +24,11 @@ replicate_layout.log
 **/.history/
 
 # 3D exports (not library files)
-**/.step
 **/*.glb
 /hardware/*.step
 
 # Production output (generated, re-exportable)
 **/production/
-
-# Fabrication toolkit config
-fabrication-toolkit-options.json
 
 # Python
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent notes
+
+Facts for AI agents working in this repo.
+
+- KiCad 10 project. Top schematic `hardware/OpenFC.kicad_sch` (hierarchical: `rp2350a`, `power`, `imu`, `osd`, `blackbox`, `pads` sub-sheets), board `hardware/OpenFC.kicad_pcb` (6 copper layers).
+- Clone with `git clone --recursive`; the `libs/KiCad-Library` submodule is referenced by the project lib tables for shared parts. Project-local libraries: `hardware/lib.kicad_sym`, `hardware/lib.pretty/`, `hardware/lib.3dshapes/`.
+- Never edit `.kicad_*` files as text. Use kicad-skip or the pcbnew API, and only for metadata (text variables, symbol BOM/doc fields). Never change nets, placement, or component values.
+- Checks and exports:
+
+```
+kicad-cli sch erc --exit-code-violations hardware/OpenFC.kicad_sch
+kicad-cli pcb drc --exit-code-violations hardware/OpenFC.kicad_pcb
+kicad-cli sch export netlist --format kicadsexpr -o /tmp/OpenFC.net hardware/OpenFC.kicad_sch
+```
+
+- Fabrication Toolkit config: `hardware/fabrication-toolkit-options.json` (tracked). Exports land in `hardware/production/` (gitignored).
+- Design detail: `hardware/docs/DESIGN.md`. Engineering research and open items: `hardware/research/`.
+- Docs are deterministic: current fact only, no TODOs or plans.
+- `main` is protected; push feature branches and open PRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Validated build, export set `OpenFC-Lite-Mini-rev2`. Substantial redesign over t
 - **R30** (10V FB, R29=100k top): 6.8k to **6.49k** (E96). Vout = 0.6 x (1 + 100/6.49) = **9.85V**, about 1.5% low, fine.
 - **C28** (10V buck output cap): **22uF 16V X5R 0603**. DC-bias derates effective C to roughly 7-11uF; with the 4.7uH inductor this raises 10V ripple but is acceptable for a digital VTX rail.
 - **L2/L3 inductors**: both rails **4.7uH (XRTC303020D4R7MBCA)**. 10V ripple about 1.17A p-p at 6S; peak well under the 3A part.
-- **U6 gyro LDO**: **NCV8187AMT180TAG** (1.2 A, high PSRR, 80 dB to 10 kHz). Gyro analog load is single-digit mA, so the rating is far in excess; kept for its PSRR. Low stock, consign if needed.
+- **U6 gyro LDO**: **NCV8187AMT180TAG** (1.2 A, high PSRR, 80 dB to 10 kHz). Gyro analog load is single-digit mA, so the 1.2 A rating is far in excess of BF section 3.1.2's 500 mA minimum; kept for its PSRR. Low stock, consign if needed.
 - **Battery reverse-polarity protection** added (RB161QS-40 Schottky, D3/D10).
 
 ### USB
@@ -43,9 +43,9 @@ Validated build, export set `OpenFC-Lite-Mini-rev2`. Substantial redesign over t
 ### Analog OSD (front-end rework)
 OSD was non-functional on Rev 1: in pass-through the monitor switched to AV (it saw a feed) but showed snow; sync reached the monitor but was too marginal to lock. Wiring and pinouts were verified correct against datasheets; this was a component-suitability and front-end problem. Root cause: the DC-coupled gain-x2 buffer parked the sync tip on the 0 V rail.
 
-- **Op-amp**: TLV9061IDPWR to **COS8051SOT (C7463385)**, a 175 MHz / 150 V/us RRIO video amp (AD8051-class), SOT-23-5. TLV9061 was under-spec for composite video (about 5 MHz closed-loop at gain 2; chroma needs about 28 V/us vs 6.5). New ref **U1**.
+- **Op-amp**: TLV9061IDPWR to **COS8051SOT (C7463385)**, a 175 MHz / 150 V/us RRIO video amp (AD8051-class), SOT-23-5. TLV9061 was under-spec for composite video (about 5 MHz closed-loop at gain 2; chroma needs about 28 V/us vs 6.5). Ref changed U19 to **U1**.
 - **OSD output front-end**: added **AC-coupling + DC-restore (sync clamp)** to bias the sync tip 0.3-0.5 V above ground before the gain stage; op-amp powered from +5 V for headroom. New nets `VID_DC` / `VID_FILT` / `OSD_LVL`.
-- **Comparator (sync sep)**: TLV3201AIDBVR to **TLV7031DPWR (C2876045)**: push-pull, RRI, X2SON-5 (about 75% smaller), 7 mV hysteresis (vs 1.2 mV). Its 3 us prop delay is symmetric, preserving HSYNC/VSYNC pulse-width discrimination, and adds a constant ~22 px horizontal offset compensated in the PIO `hshiftA/B/C` timing (about 225 clocks). Fallback if the X2SON regresses sync: TLV3201AIDCKR (SC70-5, pin-compatible, 40 ns). New ref **U2**.
+- **Comparator (sync sep)**: TLV3201AIDBVR to **TLV7031DPWR (C2876045)**: push-pull, RRI, X2SON-5 (about 75% smaller), 7 mV hysteresis (vs 1.2 mV). Its 3 us prop delay is symmetric, preserving HSYNC/VSYNC pulse-width discrimination, and adds a constant ~22 px horizontal offset that the PIO `hshiftA/B/C` timing must absorb (about 225 clocks). Fallback if the X2SON regresses sync: TLV3201AIDCKR (SC70-5, pin-compatible, 40 ns). Ref changed U20 to **U2**.
 - **OSD_EN select pull-down**: weak pull-down on U18 pin 6 (S / OSD_EN) so the select never floats and defaults to pass-through before firmware drives the GPIO.
 - **U18 SN74LVC1G3157DTBR** and **D9 SDM02U30LP3-7B**: unchanged, verified correct.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+Newest first. Dates are fabrication export dates.
+
+## Rev2 (2026-06-04)
+
+Validated build, export set `OpenFC-Lite-Mini-rev2`. Substantial redesign over the Rev 1 prototype; all schematic and board edits made manually in KiCad. Remaining open items: [`hardware/research/open-items.md`](hardware/research/open-items.md).
+
+### MCU
+- **RP2354B (QFN-80) to RP2354A (QFN-60).** 48 to 30 GPIO. The peripheral map was re-derived from scratch and now uses every GPIO (see [DESIGN.md](hardware/docs/DESIGN.md)). Reference designators were fully re-annotated. Dropped vs the QFN-80 layout: the second PIO UART, the SBUS hardware inverter, and the separate RSSI / external-ADC analog inputs.
+- **Internal core SMPS inductor (L4, 3.3uH)** added on VREG_LX for the RP2354A's integrated 1.1V buck.
+
+### Power
+- **U3/U4 bucks**: LMR51420 (2A) to **LMR51430YFDDCR** (3A, C5219261), same SOT-23-6.
+- **R30** (10V FB, R29=100k top): 6.8k to **6.49k** (E96). Vout = 0.6 x (1 + 100/6.49) = **9.85V**, about 1.5% low, fine.
+- **C28** (10V buck output cap): **22uF 16V X5R 0603**. DC-bias derates effective C to roughly 7-11uF; with the 4.7uH inductor this raises 10V ripple but is acceptable for a digital VTX rail.
+- **L2/L3 inductors**: both rails **4.7uH (XRTC303020D4R7MBCA)**. 10V ripple about 1.17A p-p at 6S; peak well under the 3A part.
+- **U6 gyro LDO**: **NCV8187AMT180TAG** (1.2 A, high PSRR, 80 dB to 10 kHz). Gyro analog load is single-digit mA, so the rating is far in excess; kept for its PSRR. Low stock, consign if needed.
+- **Battery reverse-polarity protection** added (RB161QS-40 Schottky, D3/D10).
+
+### USB
+- **R15/R24/R37** (USB series resistors): kept at 30R. USB FS is impedance-tolerant; a single resistor value is better DFM.
+
+### LEDs
+- All indicator LEDs **0201 to 0402** (0201 too fragile: broke during nut install).
+- **D2** (LED0 status, GPIO26): green to **blue** (XL-1005UBC, C22355736), per BF section 3.1.4.6.
+- **LED series resistors recalculated for about 1mA** (greens = XL-1005UGC, C965793):
+
+  | LED | Color | Source | New R (E24) | I |
+  |---|---|---|---|---|
+  | D2 (LED0) | Blue | GPIO26 (~3.3V) | 510R | ~1.0mA |
+  | D7 | Green | +3.3V | 680R | ~1.0mA |
+  | D5 | Green | +5V (5V_BUCK) | 2.4k | ~1.0mA |
+  | D4 | Green | +10V | 7.5k | ~1.0mA |
+
+### Signals / connectivity
+- **IMU and microSD split onto separate SPI buses**: IMU on **SPI1** (SCK/MOSI/MISO = GPIO10/11/12, CS=GPIO13, INT=GPIO9); microSD on **SPI0** (SCK/MOSI/MISO = GPIO18/19/20, CS=GPIO21). CS lines grouped into each bus. IMU CLKIN/SYNC is not routed to the MCU (ST gyro, no spare GPIO).
+- **SBUS inverter removed.** BF PICO inverts at the RP2350 pad IO-mux (`gpio_set_inover/outover(GPIO_OVERRIDE_INVERT)`), auto-set for SBUS on native and PIO UARTs. The RX line wires straight to a UART RX GPIO; firmware inverts.
+- **ESC connector P1**: now an 8-pin JST SH (SM08B-SRSS-TB) with the corrected, mirrored pinout. Rev 1 used a reversed generic header, a safety-critical defect: the old pinout shorted VBAT to a GPIO on a standard BF harness.
+- **Beeper**: N-MOS low-side switch (Q-FET + 1k gate + 100k pulldown, BEEPER = GPIO17). Flyback diode across the buzzer.
+- **microSD** wired compatible with both SPI and SDIO; uses **SPI**. Betaflight PICO supports SD blackbox over SPI only (PR #14567); SDIO would give about 10x throughput but needs a 4-bit HW bus and firmware that does not exist.
+
+### Analog OSD (front-end rework)
+OSD was non-functional on Rev 1: in pass-through the monitor switched to AV (it saw a feed) but showed snow; sync reached the monitor but was too marginal to lock. Wiring and pinouts were verified correct against datasheets; this was a component-suitability and front-end problem. Root cause: the DC-coupled gain-x2 buffer parked the sync tip on the 0 V rail.
+
+- **Op-amp**: TLV9061IDPWR to **COS8051SOT (C7463385)**, a 175 MHz / 150 V/us RRIO video amp (AD8051-class), SOT-23-5. TLV9061 was under-spec for composite video (about 5 MHz closed-loop at gain 2; chroma needs about 28 V/us vs 6.5). New ref **U1**.
+- **OSD output front-end**: added **AC-coupling + DC-restore (sync clamp)** to bias the sync tip 0.3-0.5 V above ground before the gain stage; op-amp powered from +5 V for headroom. New nets `VID_DC` / `VID_FILT` / `OSD_LVL`.
+- **Comparator (sync sep)**: TLV3201AIDBVR to **TLV7031DPWR (C2876045)**: push-pull, RRI, X2SON-5 (about 75% smaller), 7 mV hysteresis (vs 1.2 mV). Its 3 us prop delay is symmetric, preserving HSYNC/VSYNC pulse-width discrimination, and adds a constant ~22 px horizontal offset compensated in the PIO `hshiftA/B/C` timing (about 225 clocks). Fallback if the X2SON regresses sync: TLV3201AIDCKR (SC70-5, pin-compatible, 40 ns). New ref **U2**.
+- **OSD_EN select pull-down**: weak pull-down on U18 pin 6 (S / OSD_EN) so the select never floats and defaults to pass-through before firmware drives the GPIO.
+- **U18 SN74LVC1G3157DTBR** and **D9 SDM02U30LP3-7B**: unchanged, verified correct.
+
+### Decisions
+- **U5 power MUX**: **TPS2116DRLR** confirmed (auto-select USB/BATT).
+- **Motor order**: silk left reversed (eases routing); resolved in the BF target's DShot resource order so M1-M4 map to the pads.
+- **SWD connector**: not added. RP2354A flashes over USB (UF2/BOOTSEL).
+- **IMU**: LSM6DSV16XTR populated for development; production part selected after bench and flight testing.
+
+## Rev1 (2026-04-28)
+
+First prototype, export set `OpenFC-Lite-Mini-rev1`. RP2354B (QFN-80). Boards received and bench brought up: the custom Betaflight target built and flashed; USB enumeration, IMU, SD-card blackbox, and the switchable 10V VTX rail confirmed working. The analog OSD chain did not work (snow, sync too marginal to lock); the Rev2 front-end rework addressed this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Setup
+
+```
+git clone --recursive https://github.com/incutec-hw/OpenFC-Lite-Mini.git
+```
+
+The `--recursive` flag pulls the `libs/KiCad-Library` submodule, which the project lib tables reference for shared parts. Use KiCad 10.
+
+## Workflow
+
+- `main` is protected. Work on a feature branch and open a pull request.
+- Edit schematics and the PCB in KiCad only. Never text-edit `.kicad_sch`, `.kicad_pcb`, or other `.kicad_*` files.
+- New shared parts (symbols, footprints, 3D models) go to [incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) via PR there, not into this repo's local libraries.
+- ERC and DRC must be clean before opening a PR:
+
+```
+kicad-cli sch erc --exit-code-violations hardware/OpenFC.kicad_sch
+kicad-cli pcb drc --exit-code-violations hardware/OpenFC.kicad_pcb
+```
+
+## Documentation
+
+Docs state current fact only: no TODOs, no plans, no aspirational content.
+
+## Licensing
+
+Contributions are licensed under CERN-OHL-S-2.0, the same license as the project.
+
+## Questions
+
+Open a GitHub issue.

--- a/README.md
+++ b/README.md
@@ -1,264 +1,93 @@
 # OpenFC-Lite-Mini
 
-Open-source Betaflight flight controller — **20×20 mm**, 6-layer, 3S–6S, built around the RP2354A microcontroller. Compact and low-cost: external RX over UART, microSD blackbox, analog OSD.
+Open-source Betaflight flight controller with a 20 x 20 mm mounting pattern, part of the incutec OpenDrone line. Built around the RP2354A (dual Cortex-M33, QFN-60, 2 MB stacked flash), with a 6-axis IMU on SPI1, microSD blackbox on SPI0, PIO-driven analog OSD, and a switchable 10V VTX rail. External RX over UART, 3S-6S input, 6-layer PCB, designed in KiCad 10 for JLCPCB assembly. Its sibling [OpenFC-Lite](https://github.com/incutec-hw/OpenFC-Lite) (30.5 x 30.5 mm, RP2354B: bigger pads, more I/O, OSD debug pads) shares this design. Full design detail: [hardware/docs/DESIGN.md](hardware/docs/DESIGN.md).
 
 <p>
-<img src="images/openfc-lite-mini-rev2-top.png" width="400" alt="OpenFC-Lite-Mini Rev 2 Top" />
-<img src="images/openfc-lite-mini-rev2-bottom.png" width="400" alt="OpenFC-Lite-Mini Rev 2 Bottom" />
+<img src="images/openfc-lite-mini-rev2-top.png" width="400" alt="OpenFC-Lite-Mini Rev 2 top" />
+<img src="images/openfc-lite-mini-rev2-bottom.png" width="400" alt="OpenFC-Lite-Mini Rev 2 bottom" />
 </p>
 
-> This repository is the **Mini** (20×20, RP2354A). Its sibling **[OpenFC-Lite](https://github.com/incutec-hw/OpenFC-Lite)** (30.5×30.5 mm, RP2354B — bigger pads, more I/O, full-size SD, and OSD debug pads) shares this design. **Both are being ordered for Rev 2.**
+## Status
 
-Build video: [How Flight Controllers Work (so I built my own)](https://www.youtube.com/watch?v=XDYZoMRJFeQ)
+**Hardware validated**, Rev2, 2026-08-05.
+Latest production export set is `OpenFC-Lite-Mini-rev2` (2026-06-04), generated with the KiCad Fabrication Toolkit for JLCPCB assembly.
 
-## Open source hardware certification
+## Certification
 
 <a href="https://certification.oshwa.org/be000027.html">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="images/oshwa-certified-dark.svg" />
-    <img src="images/oshwa-certified.svg" width="160" alt="OSHWA Certified Open Source Hardware — BE000027" />
+    <img src="images/oshwa-certified.svg" width="160" alt="OSHWA Certified Open Source Hardware, BE000027" />
   </picture>
 </a>
 
 OpenFC-Lite-Mini is **certified open source hardware** by the [Open Source Hardware Association](https://www.oshwa.org/), OSHWA UID **[BE000027](https://certification.oshwa.org/be000027.html)**.
 
-## At a glance
-
-| | |
-|---|---|
-| MCU | RP2354A — dual Cortex-M33 @ 150 MHz, 2 MB stacked flash, QFN-60 (30 GPIO) |
-| IMU | LSM6DSV16XTR 6-axis, SPI1 (LGA-14 footprint; production part not yet locked, see [IMU](#imu)) |
-| Blackbox | microSD card slot (TF-021B-H265) on SPI0 |
-| OSD | analog, PIO-driven (sync separator + video op-amp + SPDT switch) |
-| Power | 3S–6S; switchable 10V (VTX/cam) + always-on 5V, reverse-polarity protected |
-| Size | 20×20 mm, 6-layer |
-| RX | external, over UART |
-| USB | USB-C, USB-CDC for configuration |
-
-Intentionally omitted to keep it small and cheap: barometer, integrated ELRS receiver, onboard WS2812B LEDs (LED-strip pad only), onboard SPI blackbox flash (microSD instead).
-
-## Status
-
-**Rev 2** is the current design: schematic and layout finalized and exported for fabrication. Rev 2 migrates the MCU from the QFN-80 RP2354B to the **QFN-60 RP2354A** (30 GPIO, fully allocated), reworks the analog-OSD front end, swaps the IMU and microSD onto separate SPI buses, and adds battery reverse-polarity protection. See the [Rev 2 Change Log](#rev-2-change-log) for the full list.
-
-**Rev 1** boards were received and brought up. The custom Betaflight target builds and flashes; USB enumeration, IMU, SD-card blackbox, and the switchable 10V VTX rail were confirmed working on bench. The analog OSD chain did not work on Rev 1 (snow, sync too marginal to lock) — the Rev 2 front-end rework addresses this and must be re-verified on the next boards.
-
-## Specifications
-
-### Core
-- **MCU:** RP2354A — dual-core ARM Cortex-M33 @ 150 MHz, 2 MB integrated stacked flash, QFN-60, 30 GPIO
-- **Clock:** 12 MHz crystal (X1) on XIN/XOUT
-- **IMU:** 6-axis MEMS on SPI1, dedicated 1.8V analog LDO (see [IMU](#imu))
-- **Blackbox:** TF-021B-H265 microSD card slot on SPI0
-- **USB:** USB-C, USB-CDC for configuration
-
-### Power tree
-| Rail | Source | Regulator | Notes |
-|---|---|---|---|
-| +10V (switchable) | +BATT | LMR51430YFDDCR (U3, 3A) | EN gated by GPIO27 (PINIO1). VTX/cam rail. 4.7µH / 22µF 16V / FB 100k:6.49k → 9.85V. |
-| +5V (always-on) | +BATT | LMR51430YFDDCR (U4, 3A) | 4.7µH inductor. |
-| +5V (USB/BATT mux) | +5V_BUCK + +5V_USB | TPS2116DRLR (U5) | Auto-selects active source. |
-| +3.3V | +5V | LP5912-3.3DRVR (U7) | 500 mA LDO. |
-| +1.8V (gyro analog) | +5V | NCV8187AMT180TAG (U6) | 1.2 A LDO, high PSRR (80 dB to 10 kHz). Isolated IMU analog supply; gyro draws only mA so the rating is far in excess. |
-| +1.1V (MCU core) | +3.3V | RP2354A internal VREG | External SMPS inductor (L4, 3.3µH) on VREG_LX. |
-
-Battery input has reverse-polarity protection (RB161QS-40 Schottky, D3/D10).
-
-### Motor outputs
-- 4× PIO-driven DShot outputs (DShot600, bidirectional telemetry supported)
-- M1=GPIO25, M2=GPIO24, M3=GPIO23, M4=GPIO22 *(descending GPIO — silk order is mapped back to M1–M4 in the Betaflight DShot resource order)*
-
-### Connectors
-- **USB-C** — configuration and firmware flashing
-- **U8** — 6-pin SMD JST SH digital VTX connector (matches Betaflight standard: +10V/GND/TX/RX/GND/SBUS)
-- **P1** — 8-pin JST SH (SM08B-SRSS-TB) ESC harness
-- I2C0 expansion pads (SDA/SCL, with pull-ups to 3.3V)
-
-### Serial / I/O
-- **UART0** (GPIO0/1) — digital VTX / MSP DisplayPort
-- **UART1** (GPIO6/7) — external serial RX (CRSF/SBUS/etc.)
-- **PIO UART0** (GPIO2/3) — software UART, default GPS
-- **I2C0** (GPIO4/5) — external expansion
-- **SPI1** (GPIO10/11/12, CS=GPIO13, INT=GPIO9) — IMU
-- **SPI0** (GPIO18/19/20, CS=GPIO21) — microSD blackbox
-
-### Analog inputs
-- VBAT sense (GPIO29 / ADC3) — divider + 1k+100nF RC filter
-- ESC current sense (GPIO28 / ADC2) — onboard sense circuit, 1k+100nF RC filter
-
-*(The QFN-60 has only 4 ADC channels — GPIO26/27 are used as digital LED0 / 10V-enable, leaving GPIO28/29 for VBAT and current. The separate RSSI and external-ADC inputs from the QFN-80 layout are not available on this part.)*
-
-### Additional
-- Addressable LED strip output (GPIO8, PIO2)
-- Status LED — LED0, blue (GPIO26)
-- Beeper output, N-MOS low-side switch (GPIO17)
-- 10V rail enable (GPIO27) — exposed as PINIO1/USER1 in firmware
-
-### Analog OSD
-- TLV7031DPWR (U2) — fast comparator, sync separator on the incoming composite video
-- COS8051SOT (U1) — wide-band video op-amp output buffer (175 MHz / 150 V/µs RRIO)
-- SN74LVC1G3157DTBR (U18) — SPDT analog switch: camera passthrough, black-pixel inject, white-pixel inject
-- AC-coupled input with DC-restore (sync clamp) front end, biasing the sync tip off the 0 V rail before the gain stage
-- Driven by RP2354A PIO2 — pixel-level timing for character overlay on PAL/NTSC composite
-
-## GPIO map
-
-All 30 GPIO of the QFN-60 are allocated:
-
-| GPIO | Function | | GPIO | Function |
-|---|---|---|---|---|
-| 0 | UART0 TX (VTX) | | 15 | OSD enable |
-| 1 | UART0 RX (VTX) | | 16 | OSD sync |
-| 2 | PIO UART0 TX (GPS) | | 17 | Beeper |
-| 3 | PIO UART0 RX (GPS) | | 18 | SPI0 SCK (microSD) |
-| 4 | I2C0 SDA | | 19 | SPI0 MOSI (microSD) |
-| 5 | I2C0 SCL | | 20 | SPI0 MISO (microSD) |
-| 6 | UART1 TX (RX) | | 21 | microSD CS |
-| 7 | UART1 RX (RX) | | 22 | Motor M4 |
-| 8 | LED strip | | 23 | Motor M3 |
-| 9 | IMU INT | | 24 | Motor M2 |
-| 10 | SPI1 SCK (IMU) | | 25 | Motor M1 |
-| 11 | SPI1 MOSI (IMU) | | 26 | LED0 status (blue) |
-| 12 | SPI1 MISO (IMU) | | 27 | 10V enable (PINIO1) |
-| 13 | IMU CS | | 28 | ESC current (ADC2) |
-| 14 | OSD write | | 29 | VBAT sense (ADC3) |
-
-## IMU
-
-The IMU footprint is LGA-14 (2.5×3 mm), routed with pins 2/3 → GND and pins 10/11 → NC, so it accepts **both TDK (ICM-426xx/456xx) and ST (LSM6D*) families**. Choosing the IMU is a part-population decision, not a layout change.
-
-- **Rev 1 and Rev 2** populate **LSM6DSV16XTR** for development.
-- **The production IMU is not yet decided** — to be selected after more bench and flight testing.
-- Note: TDK parts use a CLKIN line to eliminate sample-timing jitter; ST parts have no CLKIN/SYNC. The IMU CLKIN net exists on the sheet but is **not routed to the MCU** on the QFN-60 (no spare GPIO) — fine for an ST gyro; revisit if a TDK IMU is chosen.
-
-## Firmware
-
-A custom Betaflight target (`OPENFC_LITE_MINI_RP2350A`, `MANUFACTURER_ID = OPFC`) defines:
-
-- Motor map matching the silkscreen (M1..M4 = GPIO25..GPIO22) via the DShot resource order
-- `USE_SDCARD_SPI` on SPI0 for blackbox
-- `USE_PINIO` on GPIO27 for the switchable 10V VTX rail
-- FB_OSD framework wired but disabled by default (enable once the analog OSD chain is verified on hardware — note the RP2350 FB_OSD driver is still an open upstream PR stack)
-
-Build (requires a Betaflight checkout with `pico-sdk` and the BF-pinned ARM toolchain):
-
-```sh
-make picotool_install
-make arm_sdk_install
-make CONFIG=OPENFC_LITE_MINI_RP2350A
-```
-
-Output is a `.uf2` in `obj/`. Hold BOOTSEL, plug in USB, and drag the UF2 onto the `RP2350` mass-storage drive that mounts.
-
-## PIO Allocation
-
-The RP2350 has 3 PIO blocks × 4 state machines (12 total):
-
-| Block | Function |
-|---|---|
-| PIO0 | DShot motor output (4 SMs, one per motor) |
-| PIO1 | Software UART (PIO UART0 — TX and RX programs) |
-| PIO2 | LED strip + analog OSD pixel timing |
-
-## Revision History
-
-| Rev | Status | Notes |
-|---|---|---|
-| **Rev 1** | prototype | RP2354B (QFN-80). Received and bench brought-up; OSD non-functional. |
-| **Rev 2** | current | RP2354A (QFN-60). Design finalized and exported for fabrication. See [Rev 2 Change Log](#rev-2-change-log). |
-
-## Rev 2 Change Log
-
-Rev 2 was a substantial redesign over the Rev 1 prototype. **All schematic and board edits are made manually in KiCad.** Items below are reflected in the current schematic. Remaining open items are tracked in [`hardware/research/open-items.md`](hardware/research/open-items.md).
-
-### MCU
-- **RP2354B (QFN-80) → RP2354A (QFN-60).** 48 → 30 GPIO. The peripheral map was re-derived from scratch and now uses every GPIO (see [GPIO map](#gpio-map)). Reference designators were fully re-annotated. Dropped vs the QFN-80 layout: the second PIO UART, the SBUS hardware inverter, and the separate RSSI / external-ADC analog inputs.
-- **Internal core SMPS inductor (L4, 3.3µH)** added on VREG_LX for the RP2354A's integrated 1.1V buck.
-
-### Power
-- **U3/U4 bucks**: LMR51420 (2A) → **LMR51430YFDDCR** (3A, C5219261), same SOT-23-6.
-- **R30** (10V FB, R29=100k top): 6.8k → **6.49k** (E96). Vout = 0.6·(1 + 100/6.49) = **9.85V** (~1.5% low — fine).
-- **C28** (10V buck output cap): **22µF 16V X5R 0603**. DC-bias derates effective C to ~7–11µF; with the 4.7µH inductor this raises 10V ripple but is acceptable for a digital VTX rail.
-- **L2/L3 inductors**: both rails **4.7µH (XRTC303020D4R7MBCA)**. 10V ripple ≈1.17A p-p at 6S; peak well under the 3A part.
-- **U6 gyro LDO**: **NCV8187AMT180TAG** (1.2 A, high PSRR 80 dB to 10 kHz) — gyro analog is single-digit mA, so hugely overspec'd; the 1.2 A rating comfortably clears BF §3.1.2's ≥500 mA. Kept for its PSRR. Low stock → consign if needed.
-- **Battery reverse-polarity protection** added (RB161QS-40 Schottky, D3/D10).
-
-### MCU / USB
-- **R12/R13/R14**: kept at 30Ω. USB FS is impedance-tolerant; single resistor value = better DFM.
-
-### LEDs
-- All indicator LEDs **0201 → 0402** (0201 too fragile — broke during nut install).
-- **D2** (LED0 status, GPIO26): green → **blue** (XL-1005UBC, C22355736). BF §3.1.4.6.
-- **LED series resistors recalculated for ~1mA** (greens = XL-1005UGC, C965793).
-
-  | LED | Color | Source | New R (E24) | I |
-  |---|---|---|---|---|
-  | D2 (LED0) | Blue | GPIO26 (~3.3V) | 510Ω | ~1.0mA |
-  | D7 | Green | +3.3V | 680Ω | ~1.0mA |
-  | D5 | Green | +5V (5V_BUCK) | 2.4kΩ | ~1.0mA |
-  | D4 | Green | +10V | 7.5kΩ | ~1.0mA |
-
-### Signals / connectivity
-- **IMU and microSD split onto separate SPI buses**: IMU on **SPI1** (SCK/MOSI/MISO = GPIO10/11/12, CS=GPIO13, INT=GPIO9); microSD on **SPI0** (SCK/MOSI/MISO = GPIO18/19/20, CS=GPIO21). CS lines grouped into each bus. IMU CLKIN/SYNC is **not routed to the MCU** (ST gyro; no spare GPIO).
-- **SBUS inverter removed.** BF PICO inverts at the RP2350 pad IO-mux (`gpio_set_inover/outover(GPIO_OVERRIDE_INVERT)`), auto-set for SBUS on native + PIO UARTs. The RX line wires straight to a UART RX GPIO; firmware inverts.
-- **ESC connector P1**: now an 8-pin JST SH (SM08B-SRSS-TB) with the corrected, mirrored pinout (was a reversed generic header on Rev 1 — a safety-critical fix; the old pinout shorted VBAT to a GPIO on a standard BF harness).
-- **Beeper**: N-MOS low-side switch (Q-FET + 1k gate + 100k pulldown, BEEPER = GPIO17). Flyback diode across the buzzer.
-- **microSD** wired compatible with both SPI and SDIO; uses **SPI** (see SDIO decision below).
-
-### Analog OSD (front-end rework)
-
-OSD was non-functional on Rev 1: in pass-through the monitor switched to AV (it saw a feed) but showed snow — sync reached the monitor but was too marginal to lock. Wiring/pinouts were verified correct against datasheets; this was a component-suitability + front-end problem. Root cause: the DC-coupled gain-×2 buffer parked the sync tip on the 0 V rail. **Bench-confirm the fix on the next boards.**
-
-- **U19 op-amp**: TLV9061IDPWR → **COS8051SOT (C7463385)** — 175 MHz / 150 V/µs RRIO video amp (AD8051-class), SOT-23-5. TLV9061 was under-spec for composite video (≈5 MHz closed-loop at gain 2; chroma needs ≈28 V/µs vs 6.5). New ref **U1**.
-- **OSD output front-end**: added **AC-coupling + DC-restore (sync clamp)** to bias the sync tip ~0.3–0.5 V above ground before the gain stage; op-amp powered from +5 V for headroom. New nets `VID_DC` / `VID_FILT` / `OSD_LVL`.
-- **U20 comparator (sync sep)**: TLV3201AIDBVR → **TLV7031DPWR (C2876045)** — push-pull, RRI, X2SON-5 (~75% smaller), 7 mV hysteresis (vs 1.2 mV). 3 µs prop delay is symmetric → preserves HSYNC/VSYNC pulse-width discrimination, adds a constant ~22 px horizontal offset → **retune PIO `hshiftA/B/C`** (drop ~225 clocks). Bench-verify field lock; conservative fallback is TLV3201AIDCKR (SC70-5, pin-compatible, 40 ns) if the X2SON regresses sync. New ref **U2**.
-- **OSD_EN select pull-down**: weak pull-down on U18 pin 6 (S / OSD_EN) so the select never floats and defaults to pass-through before firmware drives the GPIO.
-- **U18 SN74LVC1G3157DTBR** and **D9 SDM02U30LP3-7B** — unchanged, verified correct.
-
-### Decisions / investigations
-- **IMU** — production part undecided; see [IMU](#imu).
-- **U5 power MUX** — **TPS2116DRLR** confirmed (auto-select USB/BATT).
-- **SDIO on Pico** — **stay on SPI.** Betaflight PICO supports SD blackbox over **SPI only** (PR #14567); no SDIO under `src/platform/PICO/`. SDIO would give ~10× throughput but needs a 4-bit HW bus *and* firmware that doesn't exist.
-- **Motor order** — silk left reversed (eases routing); resolved in the BF target's DShot resource order so M1–M4 map to the pads.
-- **SWD connector** — **not adding.** RP2354A flashes over USB (UF2/BOOTSEL); SWD pads optional.
-
-## Repository Structure
-
-```
-OpenFC-Lite-Mini/
-├── README.md
-├── LICENSE
-├── hardware/                ← KiCad 9 project, libraries, and production files
-│   ├── OpenFC.kicad_pro     ← Project file
-│   ├── OpenFC.kicad_pcb     ← PCB layout
-│   ├── OpenFC.kicad_sch     ← Top-level schematic (hierarchical)
-│   ├── *.kicad_sch          ← Sub-sheets
-│   ├── lib.kicad_sym        ← Project-local symbol library
-│   ├── lib.pretty/          ← Project-local footprint library
-│   ├── lib.3dshapes/        ← Project-local 3D models
-│   ├── production/          ← JLCPCB production exports, per revision (gitignored — re-exportable)
-│   ├── research/            ← IMU selection, routing validation, open items
-│   └── tools/               ← Analysis scripts (Python, kicad-skip / pcbnew API)
-└── images/                  ← Board renders
-```
-
-All symbol, footprint, and 3D model libraries are project-local — no external library setup required.
-
-## Schematic Hierarchy
-
-- `OpenFC.kicad_sch` — top-level
-- `rp2350a.kicad_sch` — RP2354A microcontroller, crystal, USB-C, status LED, supporting circuitry
-- `power.kicad_sch` — power supply and regulation (10V buck, 5V buck, 3.3V/1.8V LDOs, 5V mux, reverse-polarity protection)
-- `imu.kicad_sch` — 6-axis IMU on SPI1 (LGA-14 2.5×3 footprint; populates LSM6DSV16XTR for dev — see [IMU](#imu))
-- `osd.kicad_sch` — analog OSD chain (TLV7031 sync sep + COS8051 video buffer + SN74LVC1G3157 switch)
-- `blackbox.kicad_sch` — TF-021B-H265 microSD card slot on SPI0
-- `pads.kicad_sch` — solder pads and connectors
+Build video: [How Flight Controllers Work (so I built my own)](https://www.youtube.com/watch?v=XDYZoMRJFeQ)
 
 ## Links
 
 - Product page: [opendrone.be/products/openfc-lite](https://opendrone.be/products/openfc-lite)
 - Video channel: [JustFPV on YouTube](https://www.youtube.com/@justfpv1432)
 
+## Specifications
+
+| Parameter | Value |
+|---|---|
+| MCU | RP2354A, dual Cortex-M33 @ 150 MHz, 2 MB stacked flash, QFN-60, 30 GPIO |
+| IMU | 6-axis on SPI1, LGA-14 footprint (ST and TDK compatible), LSM6DSV16XTR populated |
+| Blackbox | microSD card slot (TF-021B-H265) on SPI0 |
+| OSD | Analog, PIO-driven: sync separator + video op-amp + SPDT switch |
+| RX | External, over UART |
+| Power | 3S-6S input, switchable 10V VTX rail + always-on 5V, reverse-polarity protected |
+| USB | USB-C, USB-CDC for configuration |
+| Firmware | Betaflight, custom target `OPENFC_LITE_MINI_RP2350A` |
+| PCB | 6-layer, 20 x 20 mm mounting pattern |
+
+Part-level detail (power tree, GPIO map, OSD front end, PIO allocation, firmware target) is in [hardware/docs/DESIGN.md](hardware/docs/DESIGN.md).
+
+## Repository layout
+
+| Path | Contents |
+|---|---|
+| `hardware/` | KiCad 10 project: schematics, PCB, project-local libraries |
+| `hardware/docs/` | Design documentation ([DESIGN.md](hardware/docs/DESIGN.md)) |
+| `hardware/research/` | IMU selection, routing validation, open items |
+| `hardware/tools/` | Analysis scripts (Python, kicad-skip / pcbnew API) |
+| `hardware/production/` | Fabrication exports per revision (generated, not tracked in git) |
+| `libs/KiCad-Library` | Shared Incutec symbol/footprint/3D library (git submodule) |
+| `images/` | Board renders and certification marks |
+
+## Design entry points
+
+- Top schematic: `hardware/OpenFC.kicad_sch` (hierarchical)
+- Sub-sheets: `rp2350a.kicad_sch` (MCU, crystal, USB-C), `power.kicad_sch`, `imu.kicad_sch`, `osd.kicad_sch`, `blackbox.kicad_sch`, `pads.kicad_sch`
+- Board layout: `hardware/OpenFC.kicad_pcb`, 6 copper layers
+
+The project-local libraries are `hardware/lib.kicad_sym`, `hardware/lib.pretty/`, and `hardware/lib.3dshapes/`; the project lib tables also reference the shared `Incutec` library from the `libs/KiCad-Library` submodule, used for new parts.
+
+## Build and export
+
+```
+git clone --recursive https://github.com/incutec-hw/OpenFC-Lite-Mini.git
+```
+
+Open `hardware/OpenFC.kicad_pro` in KiCad 10. Production exports (gerbers, BOM, CPL) are generated with the [KiCad Fabrication Toolkit](https://github.com/bennymeg/Fabrication-Toolkit) plugin. Headless checks and exports use `kicad-cli`:
+
+```
+kicad-cli sch erc --exit-code-violations hardware/OpenFC.kicad_sch
+kicad-cli pcb drc --exit-code-violations hardware/OpenFC.kicad_pcb
+kicad-cli pcb export gerbers -o out/ hardware/OpenFC.kicad_pcb
+```
+
+## Manufacturing
+
+Fabricated and assembled at JLCPCB: 6-layer board, LCSC parts. Per-revision BOM, CPL, and gerber sets are generated into `hardware/production/` (gitignored) with the Fabrication Toolkit, using the tracked `hardware/fabrication-toolkit-options.json`. Revision history: [CHANGELOG.md](CHANGELOG.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## License
 
-Hardware licensed under [CERN-OHL-S-2.0](https://ohwr.org/cern_ohl_s_v2.txt). See [LICENSE](LICENSE) for details.
+Hardware licensed under [CERN-OHL-S-2.0](https://ohwr.org/cern_ohl_s_v2.txt). See [LICENSE](LICENSE).

--- a/hardware/docs/DESIGN.md
+++ b/hardware/docs/DESIGN.md
@@ -1,0 +1,127 @@
+# OpenFC-Lite-Mini Design Notes
+
+Detailed design description of the OpenFC-Lite-Mini. Values are extracted from the KiCad design files: `hardware/OpenFC.kicad_sch` and its sub-sheets, `hardware/OpenFC.kicad_pcb`.
+
+## Architecture
+
+Betaflight flight controller on the RP2354A: dual-core ARM Cortex-M33 @ 150 MHz, 2 MB integrated stacked flash, QFN-60, 30 GPIO, all allocated. 12 MHz crystal (X1) on XIN/XOUT. USB-C with USB-CDC for configuration and UF2 flashing.
+
+Intentionally omitted to keep the board small and cheap: barometer, integrated ELRS receiver, onboard WS2812B LEDs (LED-strip pad only), onboard SPI blackbox flash (microSD instead).
+
+## Power tree
+
+| Rail | Source | Regulator | Notes |
+|---|---|---|---|
+| +10V (switchable) | +BATT | LMR51430YFDDCR (U3, 3A) | EN gated by GPIO27 (PINIO1). VTX/cam rail. 4.7uH / 22uF 16V / FB 100k:6.49k, Vout 9.85V |
+| +5V (always-on) | +BATT | LMR51430YFDDCR (U4, 3A) | 4.7uH inductor |
+| +5V (USB/BATT mux) | +5V_BUCK + +5V_USB | TPS2116DRLR (U5) | Auto-selects active source |
+| +3.3V | +5V | LP5912-3.3DRVR (U7) | 500 mA LDO |
+| +1.8V (gyro analog) | +5V | NCV8187AMT180TAG (U6) | 1.2 A LDO, high PSRR (80 dB to 10 kHz), isolated IMU analog supply; gyro load is single-digit mA |
+| +1.1V (MCU core) | +3.3V | RP2354A internal VREG | External SMPS inductor (L4, 3.3uH) on VREG_LX |
+
+Both buck inductors are 4.7uH (XRTC303020D4R7MBCA). Battery input has reverse-polarity protection (RB161QS-40 Schottky, D3/D10).
+
+## Motor outputs
+
+4x PIO-driven DShot outputs (DShot600, bidirectional telemetry supported). M1=GPIO25, M2=GPIO24, M3=GPIO23, M4=GPIO22: descending GPIO order, mapped back to M1-M4 in the Betaflight DShot resource order (silk order left reversed to ease routing).
+
+## Connectors
+
+- **USB-C**: configuration and firmware flashing
+- **U8**: 6-pin SMD JST SH digital VTX connector, Betaflight standard pinout (+10V/GND/TX/RX/GND/SBUS)
+- **P1**: 8-pin JST SH (SM08B-SRSS-TB) ESC harness
+- I2C0 expansion pads (SDA/SCL, pull-ups to 3.3V)
+
+## Serial and I/O
+
+- **UART0** (GPIO0/1): digital VTX / MSP DisplayPort
+- **UART1** (GPIO6/7): external serial RX (CRSF/SBUS/etc.)
+- **PIO UART0** (GPIO2/3): software UART, default GPS
+- **I2C0** (GPIO4/5): external expansion
+- **SPI1** (GPIO10/11/12, CS=GPIO13, INT=GPIO9): IMU
+- **SPI0** (GPIO18/19/20, CS=GPIO21): microSD blackbox
+
+## Analog inputs
+
+- VBAT sense (GPIO29 / ADC3): divider + 1k+100nF RC filter
+- ESC current sense (GPIO28 / ADC2): onboard sense circuit, 1k+100nF RC filter
+
+The QFN-60 has only 4 ADC channels; GPIO26/27 are used as digital LED0 and 10V-enable, leaving GPIO28/29 for VBAT and current. The separate RSSI and external-ADC inputs from the QFN-80 layout are not available on this part.
+
+## Additional I/O
+
+- Addressable LED strip output (GPIO8, PIO2)
+- Status LED: LED0, blue (GPIO26)
+- Beeper output, N-MOS low-side switch (GPIO17), flyback diode across the buzzer
+- 10V rail enable (GPIO27), exposed as PINIO1/USER1 in firmware
+
+## GPIO map
+
+All 30 GPIO of the QFN-60 are allocated:
+
+| GPIO | Function | | GPIO | Function |
+|---|---|---|---|---|
+| 0 | UART0 TX (VTX) | | 15 | OSD enable |
+| 1 | UART0 RX (VTX) | | 16 | OSD sync |
+| 2 | PIO UART0 TX (GPS) | | 17 | Beeper |
+| 3 | PIO UART0 RX (GPS) | | 18 | SPI0 SCK (microSD) |
+| 4 | I2C0 SDA | | 19 | SPI0 MOSI (microSD) |
+| 5 | I2C0 SCL | | 20 | SPI0 MISO (microSD) |
+| 6 | UART1 TX (RX) | | 21 | microSD CS |
+| 7 | UART1 RX (RX) | | 22 | Motor M4 |
+| 8 | LED strip | | 23 | Motor M3 |
+| 9 | IMU INT | | 24 | Motor M2 |
+| 10 | SPI1 SCK (IMU) | | 25 | Motor M1 |
+| 11 | SPI1 MOSI (IMU) | | 26 | LED0 status (blue) |
+| 12 | SPI1 MISO (IMU) | | 27 | 10V enable (PINIO1) |
+| 13 | IMU CS | | 28 | ESC current (ADC2) |
+| 14 | OSD write | | 29 | VBAT sense (ADC3) |
+
+## IMU
+
+The IMU footprint is LGA-14 (2.5 x 3 mm), routed with pins 2/3 to GND and pins 10/11 NC, so it accepts both TDK (ICM-426xx/456xx) and ST (LSM6D*) families. Choosing the IMU is a part-population decision, not a layout change. Rev 1 and Rev 2 populate the **LSM6DSV16XTR** for development; the production IMU is selected after bench and flight testing (comparison data: `hardware/research/imu-selection/`). The IMU runs from a dedicated 1.8V analog LDO (U6).
+
+TDK parts use a CLKIN line to eliminate sample-timing jitter; ST parts have no CLKIN/SYNC. The IMU CLKIN net exists on the sheet but is not routed to the MCU on the QFN-60 (no spare GPIO): fine for an ST gyro, revisit if a TDK IMU is chosen.
+
+## Analog OSD
+
+- TLV7031DPWR (U2): fast comparator, sync separator on the incoming composite video
+- COS8051SOT (U1): wide-band video op-amp output buffer (175 MHz / 150 V/us RRIO)
+- SN74LVC1G3157DTBR (U18): SPDT analog switch: camera passthrough, black-pixel inject, white-pixel inject
+- AC-coupled input with DC-restore (sync clamp) front end, biasing the sync tip off the 0 V rail before the gain stage
+- Driven by RP2354A PIO2: pixel-level timing for character overlay on PAL/NTSC composite
+
+## PIO allocation
+
+The RP2350 has 3 PIO blocks x 4 state machines (12 total):
+
+| Block | Function |
+|---|---|
+| PIO0 | DShot motor output (4 SMs, one per motor) |
+| PIO1 | Software UART (PIO UART0, TX and RX programs) |
+| PIO2 | LED strip + analog OSD pixel timing |
+
+## Firmware
+
+A custom Betaflight target (`OPENFC_LITE_MINI_RP2350A`, `MANUFACTURER_ID = OPFC`) defines:
+
+- Motor map matching the silkscreen (M1..M4 = GPIO25..GPIO22) via the DShot resource order
+- `USE_SDCARD_SPI` on SPI0 for blackbox
+- `USE_PINIO` on GPIO27 for the switchable 10V VTX rail
+- FB_OSD wired but disabled by default. The RP2350 FB_OSD driver is merged upstream (betaflight/betaflight#14882, merged 2026-04-22).
+
+The target config is not yet published in [betaflight/config](https://github.com/betaflight/config); building requires adding the target files to a Betaflight checkout (with `pico-sdk` and the BF-pinned ARM toolchain):
+
+```sh
+make picotool_install
+make arm_sdk_install
+make CONFIG=OPENFC_LITE_MINI_RP2350A
+```
+
+Output is a `.uf2` in `obj/`. Hold BOOTSEL, plug in USB, and drag the UF2 onto the `RP2350` mass-storage drive that mounts.
+
+Betaflight PICO supports SD blackbox over SPI only (PR #14567, no SDIO under `src/platform/PICO/`), so the microSD is wired for SPI even though the slot routing is SDIO-compatible. SBUS inversion is handled at the RP2350 pad IO-mux (`gpio_set_inover/outover(GPIO_OVERRIDE_INVERT)`), auto-set for SBUS on native and PIO UARTs, so there is no hardware inverter: the RX line wires straight to a UART RX GPIO.
+
+## Variants and revisions
+
+This repo is the 20x20 member of the OpenFC-Lite family. Its sibling [OpenFC-Lite](https://github.com/incutec-hw/OpenFC-Lite) (30.5 x 30.5 mm, RP2354B QFN-80: bigger pads, more I/O, OSD debug pads) shares this design. Fabrication sets are generated per revision into `hardware/production/` (gitignored) with the Fabrication Toolkit; the revision history is in [CHANGELOG.md](../../CHANGELOG.md). Open engineering items are tracked in [`hardware/research/open-items.md`](../research/open-items.md).

--- a/hardware/research/open-items.md
+++ b/hardware/research/open-items.md
@@ -3,12 +3,13 @@
 Unresolved items carried out of the Rev 2 change log. Resolve before the next production
 export.
 
-## U3/U4 BOM fields stale after buck upgrade
+## U3/U4 BOM fields carry a `TI ` prefix
 
 U3/U4 were changed from LMR51420YDDCR (2 A) to LMR51430YFDDCR (3 A, LCSC C5219261), same
-SOT-23-6, but the symbol fields were not fully updated: the Value still carries a `TI `
-prefix and the MPN/LCSC field still reads `LMR51420YDDCR`. Clean both fields so LCSC/MPN
-exact-match resolves to the LMR51430 (C5219261) for assembly.
+SOT-23-6. The MPN field now reads `TI LMR51430YFDDCR` (correct part) and the LCSC field
+reads `C5219261` (correct). Remaining work: strip the `TI ` prefix from the Value and MPN
+fields so MPN exact-match resolves cleanly, and optionally rename the library symbol,
+which is still named `lib:LMR51420YDDCR`.
 
 ## D1 USB ESD protection (USBLC6-2P6) not placed
 
@@ -17,8 +18,9 @@ most-exposed interface, the RP2354A PHY is not rated for system-level ESD
 (IEC 61000-4-2, 8 kV), and the part is tiny, cheap, and low-capacitance. Decision
 pending.
 
-## FB_OSD upstream driver not merged
+## FB_OSD bench verification pending
 
-The RP2350 analog-OSD driver PR stack (betaflight/betaflight#14882) is still open
-upstream; there is no flyable upstream binary yet. The custom target wires the FB_OSD
-framework but ships it disabled by default. Track the PR stack before tape-out.
+The RP2350 FB_OSD driver merged upstream on 2026-04-22 (betaflight/betaflight#14882;
+`src/platform/PICO/osd/` now exists upstream). The custom target wires the FB_OSD
+framework but ships it disabled by default. Remaining work: bench-verify the analog OSD
+chain with FB_OSD enabled on Rev 2 hardware.


### PR DESCRIPTION
Applies the OpenDrone repo standard (reference: OpenESC-30x30) to this repo.

## Changes

- **README.md**: rewritten to the standard section order (overview, Status, Certification, video + Links, Specifications, Repository layout, Design entry points, Build and export, Manufacturing, Contributing, License). Status: Hardware validated, Rev2, 2026-08-05; latest export set `OpenFC-Lite-Mini-rev2` (2026-06-04). Existing video line and Links section kept.
- **hardware/docs/DESIGN.md** (new): relocated design detail: architecture, power tree, motor outputs, connectors, serial/analog I/O, GPIO map, IMU notes, analog OSD chain, PIO allocation, firmware target, variants.
- **CHANGELOG.md** (new): revision history. Rev1 bring-up results and the full Rev 2 change list relocated here from the README.
- **CONTRIBUTING.md**, **AGENTS.md** (new): mirrored from the reference repo, adapted to this repo's file names.
- **.gitignore**: dropped stale rules that named already-tracked files (`fabrication-toolkit-options.json`, `*.kicad_dru`) and a `**/.step` typo pattern. `hardware/fabrication-toolkit-options.json` was already tracked, so no new commit needed for it.
- Nothing deleted, only relocated; legacy project names purged from prose.

## Fact-check findings fixed

- FB_OSD claim (2 occurrences): BF#14882 merged upstream 2026-04-22; docs now state merged, with bench verification on Rev 2 hardware as the remaining item (DESIGN.md + `hardware/research/open-items.md`).
- Sibling description: dropped the wrong "full-size SD" claim for OpenFC-Lite.
- USB series resistors: R12/R13/R14 corrected to R15/R24/R37 (post re-annotation designators) in the relocated change log.
- U3/U4 open item: updated to current fact, MPN already reads the LMR51430 and LCSC is already C5219261; remaining work is the `TI ` prefix (and the stale library symbol name).
- KiCad 9 corrected to KiCad 10.
- Betaflight target: docs now state the target config is not published in betaflight/config and the build requires adding the target files.
- "Both are being ordered for Rev 2" replaced with the dated export fact.

## Findings skipped (require .kicad_* edits)

- Stripping the `TI ` prefix from U3/U4 Value/MPN fields and renaming the `lib:LMR51420YDDCR` symbol: schematic metadata edit, left for a kicad-skip pass.
- Publishing the `OPENFC_LITE_MINI_RP2350A` target config upstream: out of scope for this repo's docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)