### PR TITLE
chore: point every GitHub link at OpenDrone-hw

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/KiCad-Library"]
 	path = libs/KiCad-Library
-	url = https://github.com/incutec-hw/KiCad-Library.git
+	url = https://github.com/OpenDrone-hw/KiCad-Library.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ A pull request touching a file locked by someone else gets closed, not merged.
 ## Setup
 
 ```
-git clone --recursive https://github.com/incutec-hw/OpenFC-Lite-Mini.git
+git clone --recursive https://github.com/OpenDrone-hw/OpenFC-Lite-Mini.git
 ```
 
 KiCad 10. The `--recursive` flag pulls `libs/KiCad-Library`, which the project
@@ -41,7 +41,7 @@ kicad-cli pcb drc --exit-code-violations hardware/OpenFC.kicad_pcb
 Add new symbols, footprints and 3D models to this repo's local libraries.
 That is the working default.
 
-[incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) is a
+[OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library) is a
 mirror of parts we already use or stock. Check it first: if the part is there,
 we have used it before, which saves sourcing work. Promoting a part into it is
 a separate deliberate step, not a requirement for contributing here.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenFC-Lite-Mini
 
-Open-source Betaflight flight controller with a 20 x 20 mm mounting pattern, part of the incutec OpenDrone line. Designed in KiCad 10 for JLCPCB assembly. Its sibling [OpenFC-Lite](https://github.com/incutec-hw/OpenFC-Lite) (30.5 x 30.5 mm, RP2354B: bigger pads, more I/O, OSD debug pads) shares this design. Specifications are below; full design detail is in [hardware/docs/DESIGN.md](hardware/docs/DESIGN.md).
+Open-source Betaflight flight controller with a 20 x 20 mm mounting pattern, part of the incutec OpenDrone line. Designed in KiCad 10 for JLCPCB assembly. Its sibling [OpenFC-Lite](https://github.com/OpenDrone-hw/OpenFC-Lite) (30.5 x 30.5 mm, RP2354B: bigger pads, more I/O, OSD debug pads) shares this design. Specifications are below; full design detail is in [hardware/docs/DESIGN.md](hardware/docs/DESIGN.md).
 
 <p>
 <img src="images/openfc-lite-mini-rev2-top.png" width="400" alt="OpenFC-Lite-Mini Rev 2 top" />
@@ -69,7 +69,7 @@ The project-local libraries are `hardware/lib.kicad_sym`, `hardware/lib.pretty/`
 ## Build and export
 
 ```
-git clone --recursive https://github.com/incutec-hw/OpenFC-Lite-Mini.git
+git clone --recursive https://github.com/OpenDrone-hw/OpenFC-Lite-Mini.git
 ```
 
 Open `hardware/OpenFC.kicad_pro` in KiCad 10. Production exports (gerbers, BOM, CPL) are generated with the [KiCad Fabrication Toolkit](https://github.com/bennymeg/Fabrication-Toolkit) plugin. Headless checks and exports use `kicad-cli`:

--- a/hardware/docs/DESIGN.md
+++ b/hardware/docs/DESIGN.md
@@ -135,7 +135,7 @@ Betaflight PICO supports SD blackbox over SPI only (PR #14567, no SDIO under `sr
 
 ## Variants and revisions
 
-This repo is the 20x20 member of the OpenFC-Lite family; the 30.5 x 30.5 mm sibling is [OpenFC-Lite](https://github.com/incutec-hw/OpenFC-Lite), described in the repository README. Open engineering items are tracked in [`hardware/research/open-items.md`](../research/open-items.md).
+This repo is the 20x20 member of the OpenFC-Lite family; the 30.5 x 30.5 mm sibling is [OpenFC-Lite](https://github.com/OpenDrone-hw/OpenFC-Lite), described in the repository README. Open engineering items are tracked in [`hardware/research/open-items.md`](../research/open-items.md).
 
 ## Revisions
 


### PR DESCRIPTION
The org was renamed `incutec-hw` → `OpenDrone-hw`. Every link here went through GitHub's rename redirect. That redirect stops working the moment `incutec-hw` is registered again, which is planned: Stan is creating a company org under that name.

Docs, README clone commands and the `.gitmodules` submodule URL. No design files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)