### PR TITLE
README: standardised link row, specs from the shop, status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,51 @@
 # OpenFC-Lite-Mini
 
-Open source Betaflight flight controller built on the RP2354A, 20 x 20 mm mounting
-pattern, part of the incutec OpenDrone line. Motor outputs are signal-level
-DShot to an external 4-in-1 ESC: no onboard motor drivers, no barometer, no
-integrated receiver.
+Open source Betaflight flight controller built on the RP2354A, 20 x 20 mm
+mounting pattern, part of the incutec OpenDrone line. Motor outputs are
+signal-level DShot to an external 4-in-1 ESC: no onboard motor drivers.
 
 <p>
 <img src="images/openfc-lite-mini-rev2-top.png" width="400" alt="OpenFC-Lite-Mini top" />
 <img src="images/openfc-lite-mini-rev2-bottom.png" width="400" alt="OpenFC-Lite-Mini bottom" />
 </p>
 
-|  |  |
+[![Status](https://img.shields.io/badge/status-alpha-e08c00)](https://github.com/OpenDrone-hw/.github/blob/main/CONTRIBUTING.md#the-life-of-a-project)
+[![Shop](https://img.shields.io/badge/shop-opendrone.be-c89d2e)](https://opendrone.be/products/openfc-lite)
+[![Discord](https://img.shields.io/badge/Discord-%23flight--controllers-5865F2?logo=discord&logoColor=white)](https://discord.com/channels/1494019459822653512/1494783056026796262)
+[![Video](https://img.shields.io/badge/YouTube-How%20Flight%20Controllers%20Work-FF0000?logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=XDYZoMRJFeQ)
+[![OSHWA](https://img.shields.io/badge/OSHWA-BE000027-0099b0)](https://certification.oshwa.org/be000027.html)
+
+## Specifications
+
+| | |
 |---|---|
-| Size | 20 x 20 mm mounting pattern |
+| Firmware | Betaflight |
 | MCU | RP2354A |
+| IMU | BMI270 |
+| Barometer | None |
 | Blackbox | microSD |
-| Firmware | [Betaflight](https://github.com/betaflight/betaflight) |
+| OSD | Analog and digital |
+| UARTs | 3 |
+| Motor outputs | 4x DShot, bidirectional |
+| RX | External, CRSF or SBUS |
+| Input | 3-6S LiPo |
+| BEC | 10 V switchable + 5 V always-on, 3 A |
+| Current sense | Yes |
+| USB | USB-C |
+| Mounting | 20 x 20 mm, 3.0 mm holes |
+| Dimensions | 26.9 x 26.9 mm |
+| PCB | 6-layer, 1.6 mm |
 
-<a href="https://certification.oshwa.org/be000027.html">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="images/oshwa-certified-dark.svg" />
-    <img src="images/oshwa-certified.svg" width="160" alt="OSHWA Certified Open Source Hardware, BE000027" />
-  </picture>
-</a>
-
-Certified open source hardware by the [Open Source Hardware Association](https://www.oshwa.org/),
-OSHWA UID **[BE000027](https://certification.oshwa.org/be000027.html)**.
+Technical write-up, part list and layout constraints: [AGENTS.md](AGENTS.md).
 
 ## In the line
 
-- [OpenFC-Lite](https://github.com/OpenDrone-hw/OpenFC-Lite): 30.5 x 30.5 mm, RP2354B, bigger pads and more I/O.
-- [OpenESC-20x20](https://github.com/OpenDrone-hw/OpenESC-20x20): the 20 x 20 mm 4-in-1 ESC this stacks with. This board has no motor
-  drivers, so it needs one.
-- [OpenRX](https://github.com/OpenDrone-hw/OpenRX): ExpressLRS receivers for the
-  4-pin receiver connector.
-
-## Get one
-
-[opendrone.be](https://opendrone.be)
-
-Build videos: [JustFPV](https://www.youtube.com/@justfpv1432)
+What pairs with what, and what is available:
+[opendrone.be](https://opendrone.be).
 
 ## Contributing
 
-Issues and pull requests are welcome on any repo. KiCad files cannot be merged,
-so say what you intend to change before you do, on
-[Discord](https://discord.gg/v3sWmTcx3R).
-
-The design itself, the part list and the layout constraints are in
-[AGENTS.md](AGENTS.md). How everything works:
-[CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
Same README shape across all five alpha repos.

- **Status** is a badge linking to the stage ladder in the org CONTRIBUTING, rather than described here.
- **Outbound links** move out of prose into one standardised row: status, shop, the product's Discord channel, its build video, OSHWA where certified.
- **Specifications** synced from the product page on opendrone.be, which is the maintained copy for now.
- **"In the line"** points at opendrone.be rather than listing siblings by hand.
- Removed: the JustFPV teardown line (now the video badge) and, on OpenESC-30x30, the bundled 3D model licence note.
- README points at `AGENTS.md` for the technical write-up and `CONTRIBUTING.md` for contributing.

All six outbound URLs verified 200.

### Four spec conflicts, website vs design files

Copied the website value and did **not** change the design files. These need your call, because in two cases the site looks wrong:

| Repo | Website | Design files |
|---|---|---|
| OpenESC-20x20 | Input **2-6S** | `DESIGN.md`: "The board is 6S only" |
| OpenESC-20x20 | PCB **1.6 mm** | 1.69 mm |
| OpenFC-Lite-Mini | **3** UARTs | 4: two hardware, two PIO |
| OpenFC-Lite-Mini | OSD **analog and digital** | Analog only, no digital VTX port |

### And one that I did not copy

The shop's OpenRX table lists **Lite-UFL antenna as "On-board ceramic"**, identical to Lite. The design files say Lite-UFL terminates at a **U.FL connector**, which is the entire point of the variant. I used U.FL. The shop page needs fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)