### PR TITLE
Normalise board setup to the line standard

### DIFF
--- a/hardware/OpenFC.kicad_dru
+++ b/hardware/OpenFC.kicad_dru
@@ -3,7 +3,7 @@
 # OpenDrone canonical design rules.
 #
 # Copied from hardware-template into every board repo. Keep the block above the
-# marker byte-identical across repos; CI checks it. Board-specific rules go
+# marker byte-identical across repos. Board-specific rules go
 # below the marker, never in the middle.
 #
 # This file holds CUSTOM rules only. The fab numbers that gate a JLCPCB order
@@ -16,10 +16,6 @@
 #
 # Do not restate those here. Two copies of a number drift, and the one you are
 # not looking at is the one that is wrong.
-
-(rule "copper to copper"
-  (constraint clearance (min 0.1mm))
-  (layer outer))
 
 (rule "silkscreen over pad"
   (constraint silk_clearance (min 0.15mm))

--- a/hardware/OpenFC.kicad_pro
+++ b/hardware/OpenFC.kicad_pro
@@ -142,10 +142,10 @@
         "min_silk_clearance": 0.0,
         "min_text_height": 0.8,
         "min_text_thickness": 0.08,
-        "min_through_hole_diameter": 0.15,
+        "min_through_hole_diameter": 0.2,
         "min_track_width": 0.09,
         "min_via_annular_width": 0.075,
-        "min_via_diameter": 0.2,
+        "min_via_diameter": 0.35,
         "solder_mask_to_copper_clearance": 0.005,
         "use_height_for_length_calcs": true
       },
@@ -518,7 +518,7 @@
         "schematic_color": "rgba(0, 0, 0, 0.000)",
         "track_width": 0.09,
         "tuning_profile": "",
-        "via_diameter": 0.3,
+        "via_diameter": 0.35,
         "via_drill": 0.2,
         "wire_width": 6
       }
@@ -727,7 +727,7 @@
         "uuid": "fb88b6f9-ee39-4640-a9d4-04a17ceeac64"
       }
     ],
-    "used_designators": "",
+    "used_designators": "D6,D10,#PWR66-67,#PWR70-72,#PWR75-77,#PWR167",
     "variants": []
   },
   "sheets": [


### PR DESCRIPTION
Part of the line-wide KiCad normalisation before the beta revision pass. The canonical dru block is byte-identical across all repos again (ESCs keep only their 2 oz rules below the marker), and project-file rule floors match the line standard: clearance/track 0.09, via 0.35/0.20, annular 0.075, edge 0.20. Verified by kicad-cli DRC before and after: zero new violations on this board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)