### PR TITLE
docs: add voltage range to input spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Maintained by [@Just4Stan](https://github.com/Just4Stan).
 | UARTs | 3 |
 | Motor outputs | 4x DShot, bidirectional |
 | RX | External, CRSF or SBUS |
-| Input | 3-6S LiPo |
+| Input | 3-6S LiPo (9.0-25.2 V) |
 | BEC | 10 V switchable + 5 V always-on, 3 A |
 | Current sense | Yes |
 | USB | USB-C |


### PR DESCRIPTION
Input row now reads 3-6S LiPo (9.0-25.2 V).

🤖 Generated with [Claude Code](https://claude.com/claude-code)